### PR TITLE
fix bug in LastBidsTrueValueSupplementaryRound

### DIFF
--- a/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/cca/CCAuction.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/cca/CCAuction.java
@@ -201,7 +201,7 @@ public class CCAuction extends Auction {
                 return;
             }
             SupplementaryRound supplementaryRound = supplementaryRoundQueue.peek();
-            SupplementaryBidCollector collector = new SupplementaryBidCollector(getNumberOfRounds() + 1, biddersToQuery, supplementaryRound, getCurrentPrices());
+            SupplementaryBidCollector collector = new SupplementaryBidCollector(this, supplementaryRound);
             log.debug("Starting supplementary round '{}'...", collector);
             submitBids(collector.collectBids());
         }

--- a/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/cca/bidcollection/SupplementaryBidCollector.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/cca/bidcollection/SupplementaryBidCollector.java
@@ -1,28 +1,25 @@
 package org.marketdesignresearch.mechlib.mechanism.auctions.cca.bidcollection;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.marketdesignresearch.mechlib.core.price.Prices;
-import org.marketdesignresearch.mechlib.mechanism.auctions.cca.bidcollection.supplementaryround.SupplementaryRound;
 import org.marketdesignresearch.mechlib.core.bid.Bids;
 import org.marketdesignresearch.mechlib.core.bidder.Bidder;
+import org.marketdesignresearch.mechlib.mechanism.auctions.cca.CCAuction;
+import org.marketdesignresearch.mechlib.mechanism.auctions.cca.bidcollection.supplementaryround.SupplementaryRound;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
 public class SupplementaryBidCollector {
 
-    private final int roundNumber;
-    private final List<? extends Bidder> bidders;
-    private final SupplementaryRound supplementaryRound;
-    private final Prices prices;
+    private final CCAuction auction;
+    private final SupplementaryRound supplementaryRound; 
 
     public Bids collectBids() {
         Bids bids = new Bids();
-        for (Bidder bidder : bidders) {
+        for (Bidder bidder : this.auction.getDomain().getBidders()) {
             log.debug("Asking bidder {} for additional bids...", bidder.getName());
-            bids.setBid(bidder, supplementaryRound.getSupplementaryBids(String.valueOf(roundNumber), bidder, prices));
+            bids.setBid(bidder, supplementaryRound.getSupplementaryBids(auction, bidder));
             log.debug("Done, bids for bidder {} collected", bidder.getName());
         }
         return bids;

--- a/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/cca/bidcollection/supplementaryround/LastBidsTrueValueSupplementaryRound.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/cca/bidcollection/supplementaryround/LastBidsTrueValueSupplementaryRound.java
@@ -1,18 +1,17 @@
 package org.marketdesignresearch.mechlib.mechanism.auctions.cca.bidcollection.supplementaryround;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
-import org.marketdesignresearch.mechlib.core.bid.Bid;
-import org.marketdesignresearch.mechlib.core.bidder.Bidder;
-import org.marketdesignresearch.mechlib.core.bid.Bids;
-import org.marketdesignresearch.mechlib.core.BundleBid;
-import org.marketdesignresearch.mechlib.core.price.Prices;
-import org.marketdesignresearch.mechlib.mechanism.auctions.cca.CCAuction;
-import lombok.Setter;
-
 import java.util.Iterator;
 
+import org.marketdesignresearch.mechlib.core.BundleBid;
+import org.marketdesignresearch.mechlib.core.bid.Bid;
+import org.marketdesignresearch.mechlib.core.bidder.Bidder;
+import org.marketdesignresearch.mechlib.mechanism.auctions.cca.CCAuction;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@EqualsAndHashCode
 public class LastBidsTrueValueSupplementaryRound implements SupplementaryRound {
 
     private static final int DEFAULT_NUMBER_OF_SUPPLEMENTARY_BIDS = 500;
@@ -20,15 +19,12 @@ public class LastBidsTrueValueSupplementaryRound implements SupplementaryRound {
     @Setter @Getter
     private int numberOfSupplementaryBids = DEFAULT_NUMBER_OF_SUPPLEMENTARY_BIDS;
 
-    private final CCAuction auction;
-
-    public LastBidsTrueValueSupplementaryRound(CCAuction auction) {
-    	this.auction = auction;
+    public LastBidsTrueValueSupplementaryRound() {
     }
 
     @Override
-    public Bid getSupplementaryBids(String id, Bidder bidder, Prices prices) {
-        Bid bid = this.auction.getLatestAggregatedBids(bidder);
+    public Bid getSupplementaryBids(CCAuction auction, Bidder bidder) {
+        Bid bid = auction.getLatestAggregatedBids(bidder);
         if (bid == null) return new Bid();
         Bid result = new Bid();
         int count = 0;
@@ -36,7 +32,7 @@ public class LastBidsTrueValueSupplementaryRound implements SupplementaryRound {
         Iterator<BundleBid> iterator = bid.getBundleBids().iterator();
         while (iterator.hasNext() && ++count < numberOfSupplementaryBids) {
             BundleBid bundleBid = iterator.next();
-            BundleBid trueValuedBundleBid = new BundleBid(bidder.getValue(bundleBid.getBundle()), bundleBid.getBundle(), "TrueValued_" + id + "_" + bundleBid.getId());
+            BundleBid trueValuedBundleBid = new BundleBid(bidder.getValue(bundleBid.getBundle()), bundleBid.getBundle(), "TrueValued_" + String.valueOf(auction.getNumberOfRounds()+1) + "_" + bundleBid.getId());
             result.addBundleBid(trueValuedBundleBid);
         }
         return result;

--- a/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/cca/bidcollection/supplementaryround/LastBidsTrueValueSupplementaryRound.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/cca/bidcollection/supplementaryround/LastBidsTrueValueSupplementaryRound.java
@@ -13,23 +13,22 @@ import lombok.Setter;
 
 import java.util.Iterator;
 
-@ToString
-@EqualsAndHashCode
 public class LastBidsTrueValueSupplementaryRound implements SupplementaryRound {
 
     private static final int DEFAULT_NUMBER_OF_SUPPLEMENTARY_BIDS = 500;
 
     @Setter @Getter
     private int numberOfSupplementaryBids = DEFAULT_NUMBER_OF_SUPPLEMENTARY_BIDS;
-    private final Bids bids;
+
+    private final CCAuction auction;
 
     public LastBidsTrueValueSupplementaryRound(CCAuction auction) {
-        this.bids = auction.getLatestAggregatedBids();
+    	this.auction = auction;
     }
 
     @Override
     public Bid getSupplementaryBids(String id, Bidder bidder, Prices prices) {
-        Bid bid = bids.getBid(bidder);
+        Bid bid = this.auction.getLatestAggregatedBids(bidder);
         if (bid == null) return new Bid();
         Bid result = new Bid();
         int count = 0;

--- a/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/cca/bidcollection/supplementaryround/ProfitMaximizingSupplementaryRound.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/cca/bidcollection/supplementaryround/ProfitMaximizingSupplementaryRound.java
@@ -1,19 +1,20 @@
 package org.marketdesignresearch.mechlib.mechanism.auctions.cca.bidcollection.supplementaryround;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
-import org.marketdesignresearch.mechlib.core.bid.Bid;
-import org.marketdesignresearch.mechlib.core.bidder.Bidder;
-import org.marketdesignresearch.mechlib.core.Bundle;
-import org.marketdesignresearch.mechlib.core.BundleBid;
-import org.marketdesignresearch.mechlib.core.price.Prices;
-import org.marketdesignresearch.mechlib.mechanism.auctions.cca.CCAuction;
-import com.google.common.collect.Sets;
-import lombok.Setter;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.marketdesignresearch.mechlib.core.Bundle;
+import org.marketdesignresearch.mechlib.core.BundleBid;
+import org.marketdesignresearch.mechlib.core.bid.Bid;
+import org.marketdesignresearch.mechlib.core.bidder.Bidder;
+import org.marketdesignresearch.mechlib.mechanism.auctions.cca.CCAuction;
+
+import com.google.common.collect.Sets;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 @ToString
 @EqualsAndHashCode
@@ -25,13 +26,13 @@ public class ProfitMaximizingSupplementaryRound implements SupplementaryRound {
     private int numberOfSupplementaryBids = DEFAULT_NUMBER_OF_SUPPLEMENTARY_BIDS;
     
     @Override
-    public Bid getSupplementaryBids(String id, Bidder bidder, Prices prices) {
-        List<Bundle> bestBundles = bidder.getBestBundles(prices, numberOfSupplementaryBids, true);
+    public Bid getSupplementaryBids(CCAuction auction, Bidder bidder) {
+        List<Bundle> bestBundles = bidder.getBestBundles(auction.getCurrentPrices(), numberOfSupplementaryBids, true);
         List<BundleBid> bestBundleBids = new ArrayList<>();
         // Add with true value for now
         int count = 0;
         for (Bundle bundle : bestBundles) {
-            bestBundleBids.add(new BundleBid(bidder.getValue(bundle), bundle, "DQ_" + id + "-" + ++count + "_Bidder_" + bidder));
+            bestBundleBids.add(new BundleBid(bidder.getValue(bundle), bundle, "DQ_" + String.valueOf(auction.getNumberOfRounds()+1) + "-" + ++count + "_Bidder_" + bidder));
         }
         return new Bid(Sets.newHashSet(bestBundleBids));
     }

--- a/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/cca/bidcollection/supplementaryround/SupplementaryRound.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/cca/bidcollection/supplementaryround/SupplementaryRound.java
@@ -2,10 +2,10 @@ package org.marketdesignresearch.mechlib.mechanism.auctions.cca.bidcollection.su
 
 import org.marketdesignresearch.mechlib.core.bid.Bid;
 import org.marketdesignresearch.mechlib.core.bidder.Bidder;
-import org.marketdesignresearch.mechlib.core.price.Prices;
+import org.marketdesignresearch.mechlib.mechanism.auctions.cca.CCAuction;
 
 public interface SupplementaryRound {
-    Bid getSupplementaryBids(String id, Bidder bidder, Prices prices);
+    Bid getSupplementaryBids(CCAuction auction, Bidder bidder);
     int getNumberOfSupplementaryBids();
 
     default String getDescription() {


### PR DESCRIPTION
The LatestAggregatedBids should be fetched when running the SupplementaryRound and not on creation.

Remove 
@ToString 
@EqualsAndHashCode

Due to possible circular reference through CCAuction