### PR TITLE
fix winnerdetermiation: scale bid values if higher than MIP.MAX_VALUE

### DIFF
--- a/src/main/java/org/marketdesignresearch/mechlib/winnerdetermination/BidBasedWinnerDetermination.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/winnerdetermination/BidBasedWinnerDetermination.java
@@ -5,24 +5,42 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.math.DoubleMath;
 import edu.harvard.econcs.jopt.solver.ISolution;
+import edu.harvard.econcs.jopt.solver.mip.MIP;
 import edu.harvard.econcs.jopt.solver.mip.Variable;
 import org.marketdesignresearch.mechlib.core.*;
+import org.marketdesignresearch.mechlib.core.bid.Bid;
 import org.marketdesignresearch.mechlib.core.bid.Bids;
 import org.marketdesignresearch.mechlib.core.bidder.Bidder;
 import org.marketdesignresearch.mechlib.instrumentation.MipInstrumentation;
 import org.marketdesignresearch.mechlib.metainfo.MetaInfo;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.*;
+import java.util.stream.Collector;
 
 public abstract class BidBasedWinnerDetermination extends WinnerDetermination {
 
     private Bids bids;
     // TODO: Make sure we're not running in the same issue as back with SATS with this HashMap
     protected Map<BundleBid, Variable> bidVariables = new HashMap<>();
+    
+    private BigDecimal scalingFactor = new BigDecimal(1);
 
     public BidBasedWinnerDetermination(Bids bids) {
         this.bids = bids;
+        
+        
+        BigDecimal maxValue = bids.getBids().stream().map(Bid::getBundleBids).flatMap(Set::stream).map(BundleBid::getAmount).reduce(BigDecimal::max).get();
+        BigDecimal maxMipValue = new BigDecimal(MIP.MAX_VALUE).multiply(new BigDecimal(.9));
+        
+        if (maxValue.compareTo(maxMipValue) == 1) {
+            this.scalingFactor = maxMipValue.divide(maxValue,RoundingMode.HALF_UP);
+        }
+    }
+    
+    protected BigDecimal getScaledBundleBidAmount(BundleBid bundleBid) {
+    	return bundleBid.getAmount().multiply(this.scalingFactor);
     }
 
     protected Bids getBids() {

--- a/src/main/java/org/marketdesignresearch/mechlib/winnerdetermination/ORWinnerDetermination.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/winnerdetermination/ORWinnerDetermination.java
@@ -36,7 +36,7 @@ public class ORWinnerDetermination extends BidBasedWinnerDetermination {
         for (Bidder bidder : bids.getBidders()) {
             for (BundleBid bundleBid : bids.getBid(bidder).getBundleBids()) {
                 Variable bidI = winnerDeterminationProgram.makeNewBooleanVar("Bid_" + bundleBid.getId());
-                winnerDeterminationProgram.addObjectiveTerm(bundleBid.getAmount().doubleValue(), bidI);
+                winnerDeterminationProgram.addObjectiveTerm(this.getScaledBundleBidAmount(bundleBid).doubleValue(), bidI);
                 bidVariables.put(bundleBid, bidI);
             }
         }

--- a/src/main/java/org/marketdesignresearch/mechlib/winnerdetermination/XORWinnerDetermination.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/winnerdetermination/XORWinnerDetermination.java
@@ -40,7 +40,7 @@ public class XORWinnerDetermination extends BidBasedWinnerDetermination {
 
                 Variable bidI = winnerDeterminationProgram.makeNewBooleanVar("Bid_" + bundleBid.getId());
                 bidVariables.put(bundleBid, bidI);
-                double bidAmount = bundleBid.getAmount().doubleValue();
+                double bidAmount = this.getScaledBundleBidAmount(bundleBid).doubleValue();
                 winnerDeterminationProgram.addObjectiveTerm(bidAmount, bidI);
                 exclusiveBids.addTerm(1, bidI);
                 for (BundleEntry entry : bundleBid.getBundle().getBundleEntries()) {


### PR DESCRIPTION
BidWinnerDetermination needs to be scaled for MRVM as bid values are higher than allowed by CPLEX.