### PR TITLE
Demand query cleanup

### DIFF
--- a/src/main/java/org/marketdesignresearch/mechlib/core/bidder/Bidder.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bidder/Bidder.java
@@ -60,27 +60,10 @@ public interface Bidder extends MipInstrumentationable {
     }
 
     /**
-     * Asks the bidder a demand query: What bundles would you choose if you'd have to pay certain prices?
-     *
-     * @param prices             the prices
-     * @param maxNumberOfBundles the maximum number of bundles to report
-     * @param allowNegative      whether or not to also report bundles when the utility of paying the given prices for the bundle would be negative
-     *
-     * If {@link WinnerDetermination.PoolMode#MODE_4} is used, the following parameters define some JOpt parameters linked to the solution pool:
-     * @param relPoolTolerance   the relative pool tolerance: {@link SolveParam#SOLUTION_POOL_MODE_4_RELATIVE_GAP_TOLERANCE}
-     * @param absPoolTolerance   the absolute pool tolerance: {@link SolveParam#SOLUTION_POOL_MODE_4_ABSOLUTE_GAP_TOLERANCE}
-     * @param poolTimeLimit      the pool time limit: {@link SolveParam#SOLUTION_POOL_MODE_4_TIME_LIMIT}
-     * @return A list of best bundles
-     */
-    List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative, double relPoolTolerance, double absPoolTolerance, double poolTimeLimit);
-
-    /**
      * Asks the bidder a demand query, without any pool tolerances or time limit.
      * @see #getBestBundles(Prices, int, boolean, double, double, double)
      */
-    default List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative) {
-        return getBestBundles(prices, maxNumberOfBundles, allowNegative, 0.0, 0.0, -1);
-    }
+    List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative);
 
     /**
      * Asks a bidder a demand query, without any pool tolerances or time limit, not accepting negative utility

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bidder/ORBidder.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bidder/ORBidder.java
@@ -64,7 +64,7 @@ public class ORBidder implements Bidder, Serializable {
     }
 
     @Override
-    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative, double relPoolTolerance, double absPoolTolerance, double poolTimeLimit) {
+    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative) {
         Bid valueMinusPrice = new Bid();
         value.getBundleValues().forEach(bundleValue -> valueMinusPrice.addBundleBid(new BundleBid(
                 bundleValue.getAmount().subtract(prices.getPrice(bundleValue.getBundle()).getAmount()),
@@ -73,9 +73,6 @@ public class ORBidder implements Bidder, Serializable {
         WinnerDetermination orWdp = new ORWinnerDetermination(new Bids(ImmutableMap.of(this, valueMinusPrice)));
         orWdp.setMipInstrumentation(getMipInstrumentation());
         orWdp.setPurpose(MipInstrumentation.MipPurpose.DEMAND_QUERY);
-        orWdp.setRelativePoolMode4Tolerance(relPoolTolerance);
-        orWdp.setAbsolutePoolMode4Tolerance(absPoolTolerance);
-        orWdp.setTimeLimitPoolMode4(poolTimeLimit);
         List<Allocation> optimalAllocations = orWdp.getBestAllocations(maxNumberOfBundles);
 
         List<Bundle> result = optimalAllocations.stream()

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bidder/UnitDemandBidder.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bidder/UnitDemandBidder.java
@@ -58,7 +58,7 @@ public class UnitDemandBidder implements Bidder, Serializable {
     }
 
     @Override
-    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative, double relPoolTolerance, double absPoolTolerance, double poolTimeLimit) {
+    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative) {
         return Sets.powerSet(new HashSet<>(goodsOfInterest)).stream()
                 .map(Bundle::of)
                 .sorted((a, b) -> getValue(b).subtract(prices.getPrice(b).getAmount()).compareTo(getValue(a).subtract(prices.getPrice(a).getAmount())))

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bidder/XORBidder.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bidder/XORBidder.java
@@ -62,8 +62,7 @@ public class XORBidder implements Bidder, Serializable {
 
     @Override
     public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative) {
-        List<Bundle> result = value.getOptimalBundleValueAt(prices, maxNumberOfBundles).stream()
-                .filter(bundleValue -> allowNegative || bundleValue.getAmount().subtract(prices.getPrice(bundleValue.getBundle()).getAmount()).signum() > 0)
+        List<Bundle> result = value.getOptimalBundleValueAt(prices, maxNumberOfBundles, allowNegative).stream()
                 .map(BundleValue::getBundle).collect(Collectors.toList());
         if (result.isEmpty()) result.add(Bundle.EMPTY);
         return result;

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bidder/XORBidder.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bidder/XORBidder.java
@@ -61,7 +61,7 @@ public class XORBidder implements Bidder, Serializable {
     }
 
     @Override
-    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative, double relPoolTolerance, double absPoolTolerance, double poolTimeLimit) {
+    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative) {
         List<Bundle> result = value.getOptimalBundleValueAt(prices, maxNumberOfBundles).stream()
                 .filter(bundleValue -> allowNegative || bundleValue.getAmount().subtract(prices.getPrice(bundleValue.getBundle()).getAmount()).signum() > 0)
                 .map(BundleValue::getBundle).collect(Collectors.toList());

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bidder/valuefunction/XORValueFunction.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bidder/valuefunction/XORValueFunction.java
@@ -48,7 +48,11 @@ public class XORValueFunction implements ValueFunction {
     }
 
     public List<BundleValue> getOptimalBundleValueAt(Prices prices, int maxNumberOfBundles) {
-        return bundleValues.stream()
+        return this.getOptimalBundleValueAt(prices, maxNumberOfBundles, false);
+    }
+    
+    public List<BundleValue> getOptimalBundleValueAt(Prices prices, int maxNumberOfBundles, boolean allowNegative) {
+        return bundleValues.stream().filter(b -> allowNegative || b.getAmount().subtract(prices.getPrice(b.getBundle()).getAmount()).signum() >= 0)
                 .sorted((a, b) -> {
                     BigDecimal first = a.getAmount().subtract(prices.getPrice(a.getBundle()).getAmount());
                     BigDecimal second = b.getAmount().subtract(prices.getPrice(b.getBundle()).getAmount());

--- a/src/main/java/org/marketdesignresearch/mechlib/instrumentation/MipInstrumentation.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/instrumentation/MipInstrumentation.java
@@ -14,6 +14,8 @@ public class MipInstrumentation {
     public static MipInstrumentation NO_OP = new MipInstrumentation();
 
     protected MipInstrumentation() {}
+    
+    public void preMIP(MipPurpose mipPurpose, IMIP mip) {}
 
     public void postMIP(MipPurpose mipPurpose, IMIP mip, IMIPResult result, Allocation bestAllocation, List<Allocation> poolAllocations) {}
 

--- a/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/Auction.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/Auction.java
@@ -38,12 +38,6 @@ public class Auction extends Mechanism implements AuctionInstrumentationable {
     private int manualBids = DEFAULT_MANUAL_BIDS;
     @Getter @Setter
     private int maxRounds = DEFAULT_MAX_ROUNDS;
-    @Getter @Setter
-    private double relativeDemandQueryTolerance = 0;
-    @Getter @Setter
-    private double absoluteDemandQueryTolerance = 0;
-    @Getter @Setter
-    private double demandQueryTimeLimit = -1;
 
     protected List<AuctionRound> rounds = new ArrayList<>();
 
@@ -99,7 +93,7 @@ public class Auction extends Mechanism implements AuctionInstrumentationable {
             List<Bundle> bundlesToBidOn;
             int numberOfBids = Math.max(allowedNumberOfBids() - getManualBids(), 1); // Propose at least one bid
             if (restrictedBids().get(bidder) == null) {
-                bundlesToBidOn = bidder.getBestBundles(getCurrentPrices(), numberOfBids, true, relativeDemandQueryTolerance, absoluteDemandQueryTolerance, demandQueryTimeLimit);
+                bundlesToBidOn = bidder.getBestBundles(getCurrentPrices(), numberOfBids, true);
             } else {
                 bundlesToBidOn = restrictedBids().get(bidder);
             }

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/paymentrules/EuclideanNorm.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/paymentrules/EuclideanNorm.java
@@ -59,7 +59,6 @@ public class EuclideanNorm extends PaymentNorm {
         IMIP newProgram = MIPWrapper.makeMIPWithoutObjective(program);
         addNormObjective(newProgram);
         IMIPResult result = solveProgram(newProgram);
-        getMipInstrumentation().postMIP(MipInstrumentation.MipPurpose.PAYMENT, newProgram, result);
         metaInfo.setLpSolveTime(result.getSolveTime());
         metaInfo.setNumberOfQPs(1);
         setProposedValues(result, program);

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/paymentrules/MultiNormCorePaymentRule.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/paymentrules/MultiNormCorePaymentRule.java
@@ -49,6 +49,7 @@ public class MultiNormCorePaymentRule extends BaseCorePaymentRule implements Cor
                 for (PaymentNorm paymentNorm : additionalNorms) {
                     paymentNorm.addNormObjective(tempProgram);
                 }
+                getMipInstrumentation().preMIP(MipInstrumentation.MipPurpose.PAYMENT, tempProgram);
                 IMIPResult mipResult = CPLEXUtils.SOLVER.solve(tempProgram);
                 getMipInstrumentation().postMIP(MipInstrumentation.MipPurpose.PAYMENT, tempProgram, mipResult);
                 MetaInfo tempMetaInfo = new MetaInfo();

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/paymentrules/PaymentNorm.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/paymentrules/PaymentNorm.java
@@ -25,6 +25,7 @@ public abstract class PaymentNorm implements CorePaymentNorm {
     }
 
     protected IMIPResult solveProgram(IMIP program) {
+    	getMipInstrumentation().preMIP(MipInstrumentation.MipPurpose.PAYMENT, program);
         IMIPResult result = CPLEXUtils.SOLVER.solve(program);
         getMipInstrumentation().postMIP(MipInstrumentation.MipPurpose.PAYMENT, program, result);
         return result;

--- a/src/main/java/org/marketdesignresearch/mechlib/winnerdetermination/WinnerDetermination.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/winnerdetermination/WinnerDetermination.java
@@ -76,6 +76,7 @@ public abstract class WinnerDetermination implements AllocationRule {
         getMIP().setSolveParam(SolveParam.DISPLAY_OUTPUT, displayOutput);
         getMIP().setSolveParam(SolveParam.ACCEPT_SUBOPTIMAL, acceptSuboptimal);
         try {
+        	mipInstrumentation.preMIP(purpose, getMIP());
             IMIPResult mipResult = new SolverClient().solve(getMIP());
             intermediateSolutions = solveIntermediateSolutions(mipResult);
             Allocation bestAllocation = adaptMIPResult(mipResult);


### PR DESCRIPTION
Following our discussion by email I cleaned the bidder demand query interface:

- remove all CPLEX parameters (Demand query will execute with its default parameters)
- add preMIP to MIPInstrumentation such that parameters for a Demand query can be changed by the user if needed

As I need the XORValueFunction to implement some new strategies I extended the DemandQuery functionallity there as well.