### PR TITLE
fix CCG Outcome for MRVM

### DIFF
--- a/src/main/java/org/marketdesignresearch/mechlib/core/BidderAllocation.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/BidderAllocation.java
@@ -35,7 +35,7 @@ public final class BidderAllocation {
     @Getter
     private final Bundle bundle;
     @Getter @EqualsAndHashCode.Exclude
-    private final Set<BundleExactValuePair> acceptedBids; // TODO: Check if this is needed
+    private final Set<? extends BundleExactValuePair> acceptedBids; // TODO: Check if this is needed
 
     public BidderAllocation(BigDecimal value, Set<? extends Good> bundle, Set<BundleExactValuePair> acceptedBids) {
         this(value, Bundle.of(bundle), acceptedBids);

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleBoundValueBid.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleBoundValueBid.java
@@ -34,5 +34,11 @@ public class BundleBoundValueBid extends BundleValueBid<BundleBoundValuePair>{
 		LinkedHashSet<BundleBoundValuePair> newBids = getBundleBids().stream().map(bid -> bid.reducedBy(payoff)).collect(Collectors.toCollection(LinkedHashSet::new));
         return new BundleBoundValueBid(newBids);
 	}
+
+	@Override
+	public BundleBoundValueBid multiply(BigDecimal scale) {
+		LinkedHashSet<BundleBoundValuePair> newBids = getBundleBids().stream().map(bid -> bid.multiply(scale)).collect(Collectors.toCollection(LinkedHashSet::new));
+        return new BundleBoundValueBid(newBids);
+	}
 	
 }

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleBoundValueBids.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleBoundValueBids.java
@@ -49,4 +49,13 @@ public class BundleBoundValueBids extends BundleValueBids<BundleBoundValueBid>{
 		return new BundleBoundValueBid();
 	}
 
+	@Override
+	public BundleValueBids<BundleBoundValueBid> multiply(BigDecimal scale) {
+		BundleBoundValueBids newBids = new BundleBoundValueBids();
+		for (Map.Entry<Bidder, BundleBoundValueBid> entry : getBidMap().entrySet()) {
+			newBids.setBid(entry.getKey(), entry.getValue().multiply(scale));
+		}
+		return newBids;
+	}
+
 }

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleBoundValuePair.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleBoundValuePair.java
@@ -61,6 +61,10 @@ public class BundleBoundValuePair extends BundleExactValuePair{
     
 	@Override
 	public BundleBoundValuePair reducedBy(BigDecimal amount) {
-		return new BundleBoundValuePair(this.getLowerBound().subtract(amount), this.getUpperBound().subtract(amount), this.getBundle(), UUID.randomUUID().toString());
+		return new BundleBoundValuePair(this.getLowerBound().subtract(amount).max(BigDecimal.ZERO), this.getUpperBound().subtract(amount).max(BigDecimal.ZERO), this.getBundle(), getId());
 	}
+	
+	public BundleBoundValuePair multiply(BigDecimal amount) {
+        return new BundleBoundValuePair(getLowerBound().multiply(amount),getUpperBound().multiply(amount), getBundle(), getId());
+    }
 }

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleExactValueBid.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleExactValueBid.java
@@ -38,4 +38,10 @@ public class BundleExactValueBid extends BundleValueBid<BundleExactValuePair>{
         }
         return result;
     }
+
+	@Override
+	public BundleExactValueBid multiply(BigDecimal scale) {
+		LinkedHashSet<BundleExactValuePair> newBids = getBundleBids().stream().map(bid -> bid.multiply(scale)).collect(Collectors.toCollection(LinkedHashSet::new));
+        return new BundleExactValueBid(newBids);
+	}
 }

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleExactValueBids.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleExactValueBids.java
@@ -100,4 +100,13 @@ public class BundleExactValueBids extends BundleValueBids<BundleExactValueBid> {
 		}
 		return new BundleExactValueBids(bidMap);
 	}
+
+	@Override
+	public BundleExactValueBids multiply(BigDecimal scale) {
+		BundleExactValueBids newBids = new BundleExactValueBids();
+		for (Map.Entry<Bidder, BundleExactValueBid> entry : getBidMap().entrySet()) {
+			newBids.setBid(entry.getKey(), entry.getValue().multiply(scale));
+		}
+		return newBids;
+	}
 }

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleExactValuePair.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleExactValuePair.java
@@ -65,13 +65,17 @@ public class BundleExactValuePair {
     public BundleExactValuePair reducedBy(BigDecimal amount) {
         return new BundleExactValuePair(getAmount().subtract(amount).max(BigDecimal.ZERO), bundle, id);
     }
+    
+    public BundleExactValuePair multiply(BigDecimal amount) {
+        return new BundleExactValuePair(getAmount().multiply(amount), bundle, id);
+    }
 
     public BundleExactValuePair withAmount(BigDecimal amount) {
         return new BundleExactValuePair(amount, bundle, id);
     }
 
     public PotentialCoalition getPotentialCoalition(Bidder bidder) {
-        return new PotentialCoalition(getGoods(), bidder, amount);
+        return new PotentialCoalition(getBundle(), bidder, amount);
     }
 
     public int countGood(Good good) {

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleValueBid.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleValueBid.java
@@ -54,6 +54,7 @@ public abstract class BundleValueBid<T extends BundleExactValuePair> implements 
     
     public abstract BundleValueBid<T> join(BundleValueBid<?> other);
 	public abstract BundleValueBid<T> reducedBy(BigDecimal payoff);
+	public abstract BundleValueBid<T> multiply(BigDecimal scale);
 
 	@Override
 	public boolean isEmpty() {

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleValueBids.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bid/bundle/BundleValueBids.java
@@ -1,5 +1,6 @@
 package org.marketdesignresearch.mechlib.core.bid.bundle;
 
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -61,6 +62,8 @@ public abstract class BundleValueBids<T extends BundleValueBid<? extends BundleE
 	public abstract BundleValueBids<T> join(BundleValueBids<?> other);
     
     public abstract BundleValueBids<T> reducedBy(Outcome outcome);
+    
+    public abstract BundleValueBids<T> multiply(BigDecimal factor);
     
 	public SingleItemBids getBidsPerSingleGood(Good good) {
         if (!getGoods().contains(good)) return new SingleItemBids(new BundleExactValueBids());

--- a/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/cca/CCAClockPhase.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/mechanism/auctions/cca/CCAClockPhase.java
@@ -2,11 +2,14 @@ package org.marketdesignresearch.mechlib.mechanism.auctions.cca;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.marketdesignresearch.mechlib.core.Domain;
 import org.marketdesignresearch.mechlib.core.bid.bundle.BundleBoundValueBids;
 import org.marketdesignresearch.mechlib.core.bid.bundle.BundleExactValueBids;
+import org.marketdesignresearch.mechlib.core.bidder.Bidder;
 import org.marketdesignresearch.mechlib.core.price.LinearPrices;
 import org.marketdesignresearch.mechlib.core.price.Prices;
 import org.marketdesignresearch.mechlib.mechanism.auctions.Auction;
@@ -14,6 +17,7 @@ import org.marketdesignresearch.mechlib.mechanism.auctions.AuctionPhase;
 import org.marketdesignresearch.mechlib.mechanism.auctions.AuctionRoundBuilder;
 import org.marketdesignresearch.mechlib.mechanism.auctions.cca.priceupdate.PriceUpdater;
 import org.marketdesignresearch.mechlib.mechanism.auctions.cca.priceupdate.SimpleRelativePriceUpdate;
+import org.marketdesignresearch.mechlib.mechanism.auctions.interactions.DemandQuery;
 import org.marketdesignresearch.mechlib.mechanism.auctions.interactions.impl.DefaultDemandQueryInteraction;
 import org.springframework.data.annotation.PersistenceConstructor;
 
@@ -43,8 +47,15 @@ public class CCAClockPhase implements AuctionPhase<BundleExactValueBids> {
 	@Override
 	public AuctionRoundBuilder<BundleExactValueBids> createNextRoundBuilder(Auction<BundleExactValueBids> auction) {
 		Prices newPrices = this.getPrices(auction);
-		return new CCAClockRoundBuilder(Collections.unmodifiableMap(auction.getDomain().getBidders().stream().collect(
-				Collectors.toMap(b -> b.getId(), b -> new DefaultDemandQueryInteraction(b.getId(), newPrices, auction),(e1, e2) -> e1,LinkedHashMap::new))), auction);
+		Map<UUID, DemandQuery> map = Collections.unmodifiableMap(auction.getDomain().getBidders().stream()
+				.collect(Collectors.toMap(
+						Bidder::getId,
+						b -> new DefaultDemandQueryInteraction(b.getId(), newPrices, auction),
+						(e1, e2) -> e1,
+						LinkedHashMap::new)
+				)
+		);
+		return new CCAClockRoundBuilder(map, auction);
 	}
 
 	private Prices getPrices(Auction<BundleExactValueBids> auction) {

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/OutcomeRuleScaler.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/OutcomeRuleScaler.java
@@ -22,40 +22,43 @@ import org.marketdesignresearch.mechlib.outcomerules.ccg.constraintgeneration.Po
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class OutcomeRuleScaler implements OutcomeRule{
-	private final BigDecimal scale;
-	private final BundleValueBids<?> originalBids;
-	private final OutcomeRule base;
-	
-	@Override
-	public void setMipInstrumentation(MipInstrumentation mipInstrumentation) {
-		this.base.setMipInstrumentation(mipInstrumentation);	
-	}
-	@Override
-	public Outcome getOutcome() {
-		Outcome originalOutome = this.base.getOutcome();
-		// create Payment with original values
-		Payment newPayment = new Payment(originalOutome.getPayment().getPaymentMap().entrySet().stream()
-					.collect(Collectors.toMap(Map.Entry::getKey, 
-							e->new BidderPayment(
-									e.getValue().getAmount().divide(this.scale,RoundingMode.HALF_UP)),(e1,e2)->e2,LinkedHashMap::new))
-					,originalOutome.getPayment().getMetaInfo());
-		
-		// create Allocation with original values
-		Map<Bidder,BidderAllocation> tradesMap = new LinkedHashMap<>();
-		for(Map.Entry<Bidder,BidderAllocation> e :originalOutome.getAllocation().getTradesMap().entrySet()) {
-			BigDecimal value = e.getValue().getAcceptedBids().stream()
-					.map(b -> originalBids.getBid(e.getKey()).getBidForBundle(b.getBundle()).getAmount())
-					.reduce(BigDecimal.ZERO,BigDecimal::add);
-			tradesMap.put(e.getKey(), new BidderAllocation(value, e.getValue().getBundle(), e.getValue().getAcceptedBids()));
-		}
-		
-		Set<PotentialCoalition> potentialCoalitions = null;
-		if(originalOutome.getAllocation().getPotentialCoalitions() != null) {
-			potentialCoalitions = originalOutome.getAllocation().getPotentialCoalitions().stream().map(p -> new PotentialCoalition(p.getBundle(), p.getBidder(), p.getValue().divide(this.scale,RoundingMode.HALF_UP))).collect(Collectors.toCollection(LinkedHashSet::new));
-		}
-		
-		Allocation newAllocation = new Allocation(tradesMap, originalBids, originalOutome.getMetaInfo(), potentialCoalitions);
-		return new Outcome(newPayment, newAllocation);
-	}
+public class OutcomeRuleScaler implements OutcomeRule {
+    private final BigDecimal scale;
+    private final BundleValueBids<?> originalBids;
+    private final OutcomeRule base;
+
+    @Override
+    public void setMipInstrumentation(MipInstrumentation mipInstrumentation) {
+        this.base.setMipInstrumentation(mipInstrumentation);
+    }
+
+    @Override
+    public Outcome getOutcome() {
+        Outcome originalOutcome = this.base.getOutcome();
+        // create Payment with original values
+        Payment newPayment = new Payment(originalOutcome.getPayment().getPaymentMap().entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> new BidderPayment(e.getValue().getAmount().divide(this.scale, RoundingMode.HALF_UP)),
+                        (e1, e2) -> e2,
+                        LinkedHashMap::new))
+                , originalOutcome.getPayment().getMetaInfo());
+
+        // create Allocation with original values
+        Map<Bidder, BidderAllocation> tradesMap = new LinkedHashMap<>();
+        for (Map.Entry<Bidder, BidderAllocation> e : originalOutcome.getAllocation().getTradesMap().entrySet()) {
+            BigDecimal value = e.getValue().getAcceptedBids().stream()
+                    .map(b -> originalBids.getBid(e.getKey()).getBidForBundle(b.getBundle()).getAmount())
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+            tradesMap.put(e.getKey(), new BidderAllocation(value, e.getValue().getBundle(), e.getValue().getAcceptedBids()));
+        }
+
+        Set<PotentialCoalition> potentialCoalitions = null;
+        if (originalOutcome.getAllocation().getPotentialCoalitions() != null) {
+            potentialCoalitions = originalOutcome.getAllocation().getPotentialCoalitions().stream().map(p -> new PotentialCoalition(p.getBundle(), p.getBidder(), p.getValue().divide(this.scale, RoundingMode.HALF_UP))).collect(Collectors.toCollection(LinkedHashSet::new));
+        }
+
+        Allocation newAllocation = new Allocation(tradesMap, originalBids, originalOutcome.getMetaInfo(), potentialCoalitions);
+        return new Outcome(newPayment, newAllocation);
+    }
 }

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/OutcomeRuleScaler.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/OutcomeRuleScaler.java
@@ -1,0 +1,60 @@
+package org.marketdesignresearch.mechlib.outcomerules;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.marketdesignresearch.mechlib.core.Allocation;
+import org.marketdesignresearch.mechlib.core.BidderAllocation;
+import org.marketdesignresearch.mechlib.core.BidderPayment;
+import org.marketdesignresearch.mechlib.core.Outcome;
+import org.marketdesignresearch.mechlib.core.Payment;
+import org.marketdesignresearch.mechlib.core.bid.bundle.BundleValueBids;
+import org.marketdesignresearch.mechlib.core.bidder.Bidder;
+import org.marketdesignresearch.mechlib.instrumentation.MipInstrumentation;
+import org.marketdesignresearch.mechlib.outcomerules.ccg.constraintgeneration.PotentialCoalition;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OutcomeRuleScaler implements OutcomeRule{
+	private final BigDecimal scale;
+	private final BundleValueBids<?> originalBids;
+	private final OutcomeRule base;
+	
+	@Override
+	public void setMipInstrumentation(MipInstrumentation mipInstrumentation) {
+		this.base.setMipInstrumentation(mipInstrumentation);	
+	}
+	@Override
+	public Outcome getOutcome() {
+		Outcome originalOutome = this.base.getOutcome();
+		// create Payment with original values
+		Payment newPayment = new Payment(originalOutome.getPayment().getPaymentMap().entrySet().stream()
+					.collect(Collectors.toMap(Map.Entry::getKey, 
+							e->new BidderPayment(
+									e.getValue().getAmount().divide(this.scale,RoundingMode.HALF_UP))))
+					,originalOutome.getPayment().getMetaInfo());
+		
+		// create Allocation with original values
+		Map<Bidder,BidderAllocation> tradesMap = new LinkedHashMap<>();
+		for(Map.Entry<Bidder,BidderAllocation> e :originalOutome.getAllocation().getTradesMap().entrySet()) {
+			BigDecimal value = e.getValue().getAcceptedBids().stream()
+					.map(b -> originalBids.getBid(e.getKey()).getBidForBundle(b.getBundle()).getAmount())
+					.reduce(BigDecimal.ZERO,BigDecimal::add);
+			tradesMap.put(e.getKey(), new BidderAllocation(value, e.getValue().getBundle(), e.getValue().getAcceptedBids()));
+		}
+		
+		Set<PotentialCoalition> potentialCoalitions = null;
+		if(originalOutome.getAllocation().getPotentialCoalitions() != null) {
+			potentialCoalitions = originalOutome.getAllocation().getPotentialCoalitions().stream().map(p -> new PotentialCoalition(p.getBundle(), p.getBidder(), p.getValue().divide(this.scale,RoundingMode.HALF_UP))).collect(Collectors.toSet());
+		}
+		
+		Allocation newAllocation = new Allocation(tradesMap, originalBids, originalOutome.getMetaInfo(), potentialCoalitions);
+		return new Outcome(newPayment, newAllocation);
+	}
+}

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/OutcomeRuleScaler.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/OutcomeRuleScaler.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -37,7 +38,7 @@ public class OutcomeRuleScaler implements OutcomeRule{
 		Payment newPayment = new Payment(originalOutome.getPayment().getPaymentMap().entrySet().stream()
 					.collect(Collectors.toMap(Map.Entry::getKey, 
 							e->new BidderPayment(
-									e.getValue().getAmount().divide(this.scale,RoundingMode.HALF_UP))))
+									e.getValue().getAmount().divide(this.scale,RoundingMode.HALF_UP)),(e1,e2)->e2,LinkedHashMap::new))
 					,originalOutome.getPayment().getMetaInfo());
 		
 		// create Allocation with original values
@@ -51,7 +52,7 @@ public class OutcomeRuleScaler implements OutcomeRule{
 		
 		Set<PotentialCoalition> potentialCoalitions = null;
 		if(originalOutome.getAllocation().getPotentialCoalitions() != null) {
-			potentialCoalitions = originalOutome.getAllocation().getPotentialCoalitions().stream().map(p -> new PotentialCoalition(p.getBundle(), p.getBidder(), p.getValue().divide(this.scale,RoundingMode.HALF_UP))).collect(Collectors.toSet());
+			potentialCoalitions = originalOutome.getAllocation().getPotentialCoalitions().stream().map(p -> new PotentialCoalition(p.getBundle(), p.getBidder(), p.getValue().divide(this.scale,RoundingMode.HALF_UP))).collect(Collectors.toCollection(LinkedHashSet::new));
 		}
 		
 		Allocation newAllocation = new Allocation(tradesMap, originalBids, originalOutome.getMetaInfo(), potentialCoalitions);

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/CCGFactory.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/CCGFactory.java
@@ -2,10 +2,11 @@ package org.marketdesignresearch.mechlib.outcomerules.ccg;
 
 import org.marketdesignresearch.mechlib.core.Outcome;
 import org.marketdesignresearch.mechlib.core.bid.bundle.BundleValueBids;
+import org.marketdesignresearch.mechlib.outcomerules.OutcomeRule;
 
 public interface CCGFactory extends MechanismFactory {
     @Override
-    CCGOutcomeRule getOutcomeRule(BundleValueBids<?> bids);
+    OutcomeRule getOutcomeRule(BundleValueBids<?> bids);
 
     void setReferencePoint(Outcome cachedReferencePoint);
 

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/CCGOutcomeRule.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/CCGOutcomeRule.java
@@ -87,12 +87,14 @@ public class CCGOutcomeRule implements OutcomeRule {
             blockingAllocation = blockingCoalitionFactory.findBlockingAllocation(bids, lastResult);
             metaInfo = metaInfo.join(blockingAllocation.getMostBlockingAllocation().getMetaInfo());
             
-            if(lastBlockingAllocationValue != null && PrecisionUtils.fuzzyEquals(lastBlockingAllocationValue, blockingAllocation.getMostBlockingAllocation().getTotalAllocationValue(), PrecisionUtils.EPSILON.scaleByPowerOfTen(1))) {
-            	comparisonPrecision = comparisonPrecision.scaleByPowerOfTen(1);
-            	if(comparisonPrecision.compareTo(BigDecimal.valueOf(0.1))>0) 
-            		throw new IllegalStateException("Precision of comparison of winner payments and block allocation decreases below 0.1 - This might be due to numerical issues. Please check your MIPs");
-            } else {
-            	comparisonPrecision = PrecisionUtils.EPSILON.scaleByPowerOfTen(1);
+            if(lastBlockingAllocationValue != null) {
+            	if(PrecisionUtils.fuzzyEquals(lastBlockingAllocationValue, blockingAllocation.getMostBlockingAllocation().getTotalAllocationValue(), PrecisionUtils.EPSILON.scaleByPowerOfTen(1))) {
+            		comparisonPrecision = comparisonPrecision.scaleByPowerOfTen(1);
+            		if(comparisonPrecision.compareTo(BigDecimal.valueOf(0.1))>0) 
+            			throw new IllegalStateException("Precision of comparison of winner payments and block allocation decreases below 0.1 - This might be due to numerical issues. Please check your MIPs");
+            	} else {
+            		comparisonPrecision = PrecisionUtils.EPSILON.scaleByPowerOfTen(1);
+            	}
             }
             
             lastBlockingAllocationValue = blockingAllocation.getMostBlockingAllocation().getTotalAllocationValue();

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/ConfigurableCCGFactory.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/ConfigurableCCGFactory.java
@@ -67,7 +67,7 @@ public class ConfigurableCCGFactory implements CCGFactory, ParameterizableCCGFac
 
         BigDecimal scalingFactor = null;
         BigDecimal maxValue = bids.getBids().stream().map(BundleValueBid::getBundleBids).flatMap(Set::stream).map(BundleExactValuePair::getAmount).reduce(BigDecimal::max).orElse(BigDecimal.ZERO);
-        BigDecimal maxMipValue = BigDecimal.valueOf(MIP.MAX_VALUE).multiply(BigDecimal.valueOf(.9));
+        BigDecimal maxMipValue = BigDecimal.valueOf(MIP.MAX_VALUE).multiply(BigDecimal.valueOf(.8));
 
         if (maxValue.compareTo(maxMipValue) > 0) {
             scalingFactor = maxMipValue.divide(maxValue, 10, RoundingMode.HALF_UP);

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/blockingallocation/BlockingCoalitionDetermination.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/blockingallocation/BlockingCoalitionDetermination.java
@@ -59,14 +59,13 @@ public class BlockingCoalitionDetermination extends ORWinnerDetermination {
         Map<Bidder, BidderAllocation> allocations = new HashMap<>(allocation.getTradesMap());
         Set<PotentialCoalition> potentialCoalitions = new HashSet<>();
         for (Bidder bidder : allocation.getWinners()) {
+            BidderAllocation oldBidderAllocation = allocation.allocationOf(bidder);
             if (previousPayoff.containsKey(bidder)) {
-                BidderAllocation oldBidderAllocation = allocation.allocationOf(bidder);
                 BigDecimal tradeValue = oldBidderAllocation.getValue().subtract(previousPayoff.get(bidder));
                 BidderAllocation bidderAllocation = new BidderAllocation(tradeValue, oldBidderAllocation.getBundle(), oldBidderAllocation.getAcceptedBids());
                 allocations.put(bidder, bidderAllocation);
                 potentialCoalitions.add(bidderAllocation.getPotentialCoalition(bidder));
             } else {
-                BidderAllocation oldBidderAllocation = allocation.allocationOf(bidder);
                 potentialCoalitions.addAll(oldBidderAllocation.getAcceptedBids().stream().map(bundleBid -> bundleBid.getPotentialCoalition(bidder)).collect(Collectors.toList()));
             }
         }

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/blockingallocation/BlockingCoalitionDetermination.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/blockingallocation/BlockingCoalitionDetermination.java
@@ -32,7 +32,7 @@ public class BlockingCoalitionDetermination extends ORWinnerDetermination {
             Variable traitor = mip.makeNewBooleanVar(TRAITOR + winningBidder.getId());
             BidderAllocation bidderAllocation = previousOutcome.getAllocation().allocationOf(winningBidder);
             BigDecimal payoff = bidderAllocation.getValue().subtract(previousOutcome.getPayment().paymentOf(winningBidder).getAmount());
-            mip.addObjectiveTerm(payoff.negate().doubleValue(), traitor);
+            mip.addObjectiveTerm(payoff.negate().multiply(getScalingFactor()).doubleValue(), traitor);
 
             // traitor is 1 if at least one bundleBid of the bidder was
             // allocated else 0

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/blockingallocation/IntermediateSolutionsAllocationFinderFactory.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/blockingallocation/IntermediateSolutionsAllocationFinderFactory.java
@@ -25,7 +25,7 @@ public class IntermediateSolutionsAllocationFinderFactory implements BlockingAll
     }
 
     public IntermediateSolutionsAllocationFinderFactory(MultiBlockingAllocationsDetermination.Mode mode) {
-        this(mode, PrecisionUtils.EPSILON);
+        this(mode, PrecisionUtils.EPSILON.scaleByPowerOfTen(2));
     }
 
     @Override

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/blockingallocation/OrStarBlockingCoalitionFinderFactory.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/blockingallocation/OrStarBlockingCoalitionFinderFactory.java
@@ -18,7 +18,7 @@ public class OrStarBlockingCoalitionFinderFactory implements BlockingAllocationF
     }
 
     public OrStarBlockingCoalitionFinderFactory() {
-        this.epsilon = PrecisionUtils.EPSILON;
+        this.epsilon = PrecisionUtils.EPSILON.scaleByPowerOfTen(2);
     }
 
     @Override

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/blockingallocation/XORBlockingCoalitionFinderFactory.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/blockingallocation/XORBlockingCoalitionFinderFactory.java
@@ -18,7 +18,7 @@ public class XORBlockingCoalitionFinderFactory implements BlockingAllocationFind
     }
 
     public XORBlockingCoalitionFinderFactory() {
-        this.epsilon = PrecisionUtils.EPSILON;
+        this.epsilon = PrecisionUtils.EPSILON.scaleByPowerOfTen(2);
     }
 
     @Override

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/FullConstraintGenerator.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/FullConstraintGenerator.java
@@ -26,7 +26,7 @@ import com.google.common.collect.Sets;
 public class FullConstraintGenerator implements PartialConstraintGenerator {
 
     @Override
-    public void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, PotentialCoalition> goodToBidderMap, CorePaymentRule corePaymentRule) {
+    public void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, Set<PotentialCoalition>> goodToBidderMap, CorePaymentRule corePaymentRule) {
 
     }
 

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/IterativePartialSeparabilityConstraintsGenerator.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/IterativePartialSeparabilityConstraintsGenerator.java
@@ -22,7 +22,7 @@ import com.google.common.collect.Sets;
 class IterativePartialSeparabilityConstraintsGenerator implements PartialConstraintGenerator {
 
     @Override
-    public void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, PotentialCoalition> goodToBidderMap, CorePaymentRule corePaymentRule) {
+    public void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, Set<PotentialCoalition>> goodToBidderMap, CorePaymentRule corePaymentRule) {
 
     }
 

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/PartialConstraintGenerator.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/PartialConstraintGenerator.java
@@ -1,6 +1,7 @@
 package org.marketdesignresearch.mechlib.outcomerules.ccg.constraintgeneration;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.jgrapht.Graph;
 import org.jgrapht.alg.connectivity.ConnectivityInspector;
@@ -30,7 +31,7 @@ interface PartialConstraintGenerator {
      * @param goodToBidderMap
      * @param bids
      */
-    void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, PotentialCoalition> goodToBidderMap, CorePaymentRule corePaymentRule);
+    void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, Set<PotentialCoalition>> goodToBidderMap, CorePaymentRule corePaymentRule);
 
     void generateConstraint(CorePaymentRule corePaymentRule, Graph<PotentialCoalition, DefaultEdge> graph,
                             ConnectivityInspector<PotentialCoalition, DefaultEdge> connectivityInspector, Allocation blockingCoalition, Outcome priorResult);

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/PartialSeparabilityConstraintGenerator.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/PartialSeparabilityConstraintGenerator.java
@@ -20,7 +20,7 @@ import org.marketdesignresearch.mechlib.outcomerules.ccg.paymentrules.CorePaymen
 class PartialSeparabilityConstraintGenerator implements PartialConstraintGenerator {
 
     @Override
-    public void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, PotentialCoalition> goodToBidderMap, CorePaymentRule corePaymentRule) {
+    public void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, Set<PotentialCoalition>> goodToBidderMap, CorePaymentRule corePaymentRule) {
 
     }
 

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/PerBidConstraintGenerator.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/PerBidConstraintGenerator.java
@@ -19,6 +19,8 @@ import org.marketdesignresearch.mechlib.core.bid.bundle.BundleValueBid;
 import org.marketdesignresearch.mechlib.core.bid.bundle.BundleValueBids;
 import org.marketdesignresearch.mechlib.core.bidder.Bidder;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.blockingallocation.BlockedBidders;
+import org.marketdesignresearch.mechlib.outcomerules.ccg.blockingallocation.BlockingAllocation;
+import org.marketdesignresearch.mechlib.outcomerules.ccg.blockingallocation.BlockingCoalitionDetermination;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.paymentrules.CorePaymentRule;
 
 import com.google.common.collect.Sets;
@@ -31,14 +33,15 @@ import com.google.common.collect.Sets;
  */
 class PerBidConstraintGenerator implements PartialConstraintGenerator {
     @Override
-    public void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, PotentialCoalition> goodToBidderMap, CorePaymentRule corePaymentRule) {
+    public void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, Set<PotentialCoalition>> goodToBidderMap, CorePaymentRule corePaymentRule) {
         corePaymentRule.resetResult();
         Allocation allocation = referencePoint.getAllocation();
         Payment lowerBound = referencePoint.getPayment();
         for (Entry<Bidder, ? extends BundleValueBid<?>> bid : bids.getBidMap().entrySet()) {
             for (BundleExactValuePair bundleBid : bid.getValue().getBundleBids()) {
-                // TODO: assumes availability of 1
-                Set<Bidder> blockedBiddersSet = bundleBid.getBundle().getBundleEntries().stream().map(BundleEntry::getGood).filter(goodToBidderMap::containsKey).map(good -> goodToBidderMap.get(good).getBidder()).collect(Collectors.toSet());
+                // TODO check implementation for availability of more than 1
+            	
+                Set<Bidder> blockedBiddersSet = bundleBid.getBundle().getBundleEntries().stream().map(BundleEntry::getGood).filter(goodToBidderMap::containsKey).flatMap(good -> goodToBidderMap.get(good).stream().map(PotentialCoalition::getBidder)).collect(Collectors.toSet());
                 BigDecimal currentValue = allocation.allocationOf(bid.getKey()) == null ? BigDecimal.ZERO : allocation.allocationOf(bid.getKey()).getValue();
                 BigDecimal currentPayment = lowerBound.paymentOf(bid.getKey()) == null ? BigDecimal.ZERO : lowerBound.paymentOf(bid.getKey()).getAmount();
                 BigDecimal blockingValue = bundleBid.getAmount().subtract(currentValue).add(currentPayment);

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/SeparabilityConstraintGenerator.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/SeparabilityConstraintGenerator.java
@@ -24,7 +24,7 @@ import org.marketdesignresearch.mechlib.outcomerules.ccg.paymentrules.CorePaymen
  */
 public class SeparabilityConstraintGenerator implements PartialConstraintGenerator {
     @Override
-    public void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, PotentialCoalition> goodToBidderMap, CorePaymentRule corePaymentRule) {
+    public void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, Set<PotentialCoalition>> goodToBidderMap, CorePaymentRule corePaymentRule) {
 
     }
 

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/StandardCCGConstraintGenerator.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/StandardCCGConstraintGenerator.java
@@ -2,6 +2,7 @@ package org.marketdesignresearch.mechlib.outcomerules.ccg.constraintgeneration;
 
 import java.math.BigDecimal;
 import java.util.Map;
+import java.util.Set;
 
 import org.jgrapht.Graph;
 import org.jgrapht.alg.connectivity.ConnectivityInspector;
@@ -16,7 +17,7 @@ import org.marketdesignresearch.mechlib.outcomerules.ccg.paymentrules.CorePaymen
 public class StandardCCGConstraintGenerator implements PartialConstraintGenerator {
 
     @Override
-    public void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, PotentialCoalition> goodToBidderMap, CorePaymentRule corePaymentRule) {
+    public void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, Set<PotentialCoalition>> goodToBidderMap, CorePaymentRule corePaymentRule) {
 
     }
 

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/ValueSeparabilityGenerator.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/constraintgeneration/ValueSeparabilityGenerator.java
@@ -38,7 +38,7 @@ public abstract class ValueSeparabilityGenerator implements PartialConstraintGen
     }
 
     @Override
-    public void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, PotentialCoalition> goodToBidderMap, CorePaymentRule corePaymentRule) {
+    public void generateFirstRoundConstraints(BundleValueBids<?> bids, Outcome referencePoint, Map<Good, Set<PotentialCoalition>> goodToBidderMap, CorePaymentRule corePaymentRule) {
         this.referencePayments = referencePoint.getPayment();
     }
 

--- a/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/paymentrules/VariableNormCCGFactory.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/outcomerules/ccg/paymentrules/VariableNormCCGFactory.java
@@ -23,7 +23,11 @@ public class VariableNormCCGFactory extends ConfigurableCCGFactory implements Me
     }
 
     public VariableNormCCGFactory(ReferencePointFactory rpFactory, List<NormFactory> normFactories) {
-        super(new XORBlockingCoalitionFinderFactory(), rpFactory, normFactories, ConstraintGenerationAlgorithm.SEPARABILITY);
+        this(rpFactory, normFactories, ConstraintGenerationAlgorithm.SEPARABILITY);
+    }
+    
+    public VariableNormCCGFactory(ReferencePointFactory rpFactory, List<NormFactory> normFactories, ConstraintGenerationAlgorithm alg) {
+        super(new XORBlockingCoalitionFinderFactory(), rpFactory, normFactories, alg);
     }
 
     public VariableNormCCGFactory(ReferencePointFactory rpFacory, Norm primaryNorm, Norm... secondaryNorms) {

--- a/src/main/java/org/marketdesignresearch/mechlib/winnerdetermination/BidBasedWinnerDetermination.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/winnerdetermination/BidBasedWinnerDetermination.java
@@ -44,8 +44,12 @@ public abstract class BidBasedWinnerDetermination extends WinnerDetermination {
         BigDecimal maxValue = bids.getBids().stream().map(BundleValueBid::getBundleBids).flatMap(Set::stream).map(BundleExactValuePair::getAmount).reduce(BigDecimal::max).get();
         BigDecimal maxMipValue = new BigDecimal(MIP.MAX_VALUE).multiply(new BigDecimal(.9));
         
-        if (maxValue.compareTo(maxMipValue) == 1) {
-            this.scalingFactor = maxMipValue.divide(maxValue,RoundingMode.HALF_UP);
+        if (maxValue.compareTo(maxMipValue) > 0) {
+            this.scalingFactor = maxMipValue.divide(maxValue, 10, RoundingMode.HALF_UP);
+            if (scalingFactor.compareTo(BigDecimal.ZERO) == 0) {
+                throw new IllegalArgumentException("Bids are are too large, scaling will not make sense because" +
+                        "it would result in a very imprecise solution. Scaling factor would be smaller than 1e-10.");
+            }
         }
     }
     

--- a/src/main/java/org/marketdesignresearch/mechlib/winnerdetermination/BidBasedWinnerDetermination.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/winnerdetermination/BidBasedWinnerDetermination.java
@@ -25,6 +25,8 @@ import com.google.common.math.DoubleMath;
 import edu.harvard.econcs.jopt.solver.ISolution;
 import edu.harvard.econcs.jopt.solver.mip.MIP;
 import edu.harvard.econcs.jopt.solver.mip.Variable;
+import lombok.AccessLevel;
+import lombok.Getter;
 
 public abstract class BidBasedWinnerDetermination extends WinnerDetermination {
 
@@ -32,7 +34,8 @@ public abstract class BidBasedWinnerDetermination extends WinnerDetermination {
     // TODO: Make sure we're not running in the same issue as back with SATS with this HashMap
     protected Map<BundleExactValuePair, Variable> bidVariables = new HashMap<>();
     
-    private BigDecimal scalingFactor = new BigDecimal(1);
+    @Getter(AccessLevel.PROTECTED)
+    private BigDecimal scalingFactor = BigDecimal.ONE;
 
     public BidBasedWinnerDetermination(BundleValueBids<?> bids) {
         this.bids = bids;
@@ -44,6 +47,11 @@ public abstract class BidBasedWinnerDetermination extends WinnerDetermination {
         if (maxValue.compareTo(maxMipValue) == 1) {
             this.scalingFactor = maxMipValue.divide(maxValue,RoundingMode.HALF_UP);
         }
+    }
+    
+    @Override
+    public void setLowerBound(double lowerBound) {
+    	super.setLowerBound(BigDecimal.valueOf(lowerBound).multiply(this.scalingFactor).doubleValue());
     }
     
     protected BigDecimal getScaledBundleBidAmount(BundleExactValuePair bundleBid) {

--- a/src/test/java/org/marketdesignresearch/mechlib/outcomerules/OutcomeRuleScalerTest.java
+++ b/src/test/java/org/marketdesignresearch/mechlib/outcomerules/OutcomeRuleScalerTest.java
@@ -2,18 +2,17 @@ package org.marketdesignresearch.mechlib.outcomerules;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import edu.harvard.econcs.jopt.solver.mip.MIP;
 import org.junit.Test;
-import org.marketdesignresearch.mechlib.core.Bundle;
-import org.marketdesignresearch.mechlib.core.Payment;
-import org.marketdesignresearch.mechlib.core.SimpleGood;
-import org.marketdesignresearch.mechlib.core.SimpleXORDomain;
+import org.marketdesignresearch.mechlib.core.*;
 import org.marketdesignresearch.mechlib.core.bid.bundle.BundleExactValueBids;
+import org.marketdesignresearch.mechlib.core.bidder.ORBidder;
 import org.marketdesignresearch.mechlib.core.bidder.XORBidder;
 import org.marketdesignresearch.mechlib.core.bidder.valuefunction.BundleValue;
+import org.marketdesignresearch.mechlib.core.bidder.valuefunction.ORValueFunction;
 import org.marketdesignresearch.mechlib.core.bidder.valuefunction.XORValueFunction;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.MechanismFactory;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.VariableAlgorithmCCGFactory;
+import org.marketdesignresearch.mechlib.outcomerules.ccg.blockingallocation.OrStarBlockingCoalitionFinderFactory;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.blockingallocation.XORBlockingCoalitionFinderFactory;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.constraintgeneration.ConstraintGenerationAlgorithm;
 import org.marketdesignresearch.mechlib.utils.CPLEXUtils;
@@ -43,6 +42,28 @@ public class OutcomeRuleScalerTest {
         SimpleXORDomain domain = new SimpleXORDomain(ImmutableList.of(westBidder1, westBidder2, globalBidder), ImmutableList.of(west));
         MechanismFactory equalNorm = new VariableAlgorithmCCGFactory(new XORBlockingCoalitionFinderFactory(), ConstraintGenerationAlgorithm.STANDARD_CCG);
         OutcomeRule outcomeRule = equalNorm.getOutcomeRule(BundleExactValueBids.fromXORBidders(domain.getBidders()));
+        Payment payment = outcomeRule.getPayment();
+        assertThat(payment.paymentOf(westBidder2).getAmount()).isEqualByComparingTo(BigDecimal.valueOf(1.5e15));
+        assertThat(payment.paymentOf(westBidder1).getAmount()).isEqualByComparingTo(BigDecimal.valueOf(1.5e15));
+    }
+    
+    @Test
+    public void testScalerForCCGinORDomain() {
+        CPLEXUtils.SOLVER.initializeSolveParams();
+        SimpleGood west = new SimpleGood("west", 2, false);
+
+        BundleValue valueWest1 = new BundleValue(BigDecimal.valueOf(2e15), Bundle.of(west));
+        ORBidder westBidder1 = new ORBidder("west1", new ORValueFunction(ImmutableSet.of(valueWest1)));
+
+        BundleValue valueWest2 = new BundleValue(BigDecimal.valueOf(2e15), Bundle.of(west));
+        ORBidder westBidder2 = new ORBidder("west2", new ORValueFunction(ImmutableSet.of(valueWest2)));
+
+        BundleValue globalBundle = new BundleValue(BigDecimal.valueOf(1.5e15), Bundle.of(west), "global");
+        ORBidder globalBidder = new ORBidder("global", new ORValueFunction(ImmutableSet.of(globalBundle)));
+
+        SimpleORDomain domain = new SimpleORDomain(ImmutableList.of(westBidder1, westBidder2, globalBidder), ImmutableList.of(west));
+        MechanismFactory equalNorm = new VariableAlgorithmCCGFactory(new OrStarBlockingCoalitionFinderFactory(), ConstraintGenerationAlgorithm.STANDARD_CCG);
+        OutcomeRule outcomeRule = equalNorm.getOutcomeRule(BundleExactValueBids.fromORBidders(domain.getBidders()));
         Payment payment = outcomeRule.getPayment();
         assertThat(payment.paymentOf(westBidder2).getAmount()).isEqualByComparingTo(BigDecimal.valueOf(1.5e15));
         assertThat(payment.paymentOf(westBidder1).getAmount()).isEqualByComparingTo(BigDecimal.valueOf(1.5e15));

--- a/src/test/java/org/marketdesignresearch/mechlib/outcomerules/OutcomeRuleScalerTest.java
+++ b/src/test/java/org/marketdesignresearch/mechlib/outcomerules/OutcomeRuleScalerTest.java
@@ -1,0 +1,50 @@
+package org.marketdesignresearch.mechlib.outcomerules;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import edu.harvard.econcs.jopt.solver.mip.MIP;
+import org.junit.Test;
+import org.marketdesignresearch.mechlib.core.Bundle;
+import org.marketdesignresearch.mechlib.core.Payment;
+import org.marketdesignresearch.mechlib.core.SimpleGood;
+import org.marketdesignresearch.mechlib.core.SimpleXORDomain;
+import org.marketdesignresearch.mechlib.core.bid.bundle.BundleExactValueBids;
+import org.marketdesignresearch.mechlib.core.bidder.XORBidder;
+import org.marketdesignresearch.mechlib.core.bidder.valuefunction.BundleValue;
+import org.marketdesignresearch.mechlib.core.bidder.valuefunction.XORValueFunction;
+import org.marketdesignresearch.mechlib.outcomerules.ccg.MechanismFactory;
+import org.marketdesignresearch.mechlib.outcomerules.ccg.VariableAlgorithmCCGFactory;
+import org.marketdesignresearch.mechlib.outcomerules.ccg.blockingallocation.XORBlockingCoalitionFinderFactory;
+import org.marketdesignresearch.mechlib.outcomerules.ccg.constraintgeneration.ConstraintGenerationAlgorithm;
+import org.marketdesignresearch.mechlib.utils.CPLEXUtils;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OutcomeRuleScalerTest {
+
+    @Test
+    public void testScalerForCCG() {
+
+        CPLEXUtils.SOLVER.initializeSolveParams();
+        SimpleGood west = new SimpleGood("west", 2, false);
+
+        BundleValue valueWest1 = new BundleValue(BigDecimal.valueOf(2e15), Bundle.of(west));
+        XORBidder westBidder1 = new XORBidder("west1", new XORValueFunction(ImmutableSet.of(valueWest1)));
+
+        BundleValue valueWest2 = new BundleValue(BigDecimal.valueOf(2e15), Bundle.of(west));
+        XORBidder westBidder2 = new XORBidder("west2", new XORValueFunction(ImmutableSet.of(valueWest2)));
+
+        BundleValue globalBundle = new BundleValue(BigDecimal.valueOf(3e15), new Bundle(Map.of(west, 2)), "global");
+        XORBidder globalBidder = new XORBidder("global", new XORValueFunction(ImmutableSet.of(globalBundle)));
+
+        SimpleXORDomain domain = new SimpleXORDomain(ImmutableList.of(westBidder1, westBidder2, globalBidder), ImmutableList.of(west));
+        MechanismFactory equalNorm = new VariableAlgorithmCCGFactory(new XORBlockingCoalitionFinderFactory(), ConstraintGenerationAlgorithm.STANDARD_CCG);
+        OutcomeRule outcomeRule = equalNorm.getOutcomeRule(BundleExactValueBids.fromXORBidders(domain.getBidders()));
+        Payment payment = outcomeRule.getPayment();
+        assertThat(payment.paymentOf(westBidder2).getAmount()).isEqualByComparingTo(BigDecimal.valueOf(1.5e15));
+        assertThat(payment.paymentOf(westBidder1).getAmount()).isEqualByComparingTo(BigDecimal.valueOf(1.5e15));
+    }
+}

--- a/src/test/java/org/marketdesignresearch/mechlib/outcomerules/ccg/PaymentRuleTests.java
+++ b/src/test/java/org/marketdesignresearch/mechlib/outcomerules/ccg/PaymentRuleTests.java
@@ -2,11 +2,14 @@ package org.marketdesignresearch.mechlib.outcomerules.ccg;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.file.Paths;
+import java.util.Map;
 
 import org.junit.Test;
+import org.marketdesignresearch.mechlib.core.Bundle;
 import org.marketdesignresearch.mechlib.core.Payment;
 import org.marketdesignresearch.mechlib.core.SimpleGood;
 import org.marketdesignresearch.mechlib.core.SimpleXORDomain;
@@ -16,6 +19,8 @@ import org.marketdesignresearch.mechlib.core.bidder.XORBidder;
 import org.marketdesignresearch.mechlib.core.bidder.valuefunction.BundleValue;
 import org.marketdesignresearch.mechlib.core.bidder.valuefunction.XORValueFunction;
 import org.marketdesignresearch.mechlib.outcomerules.OutcomeRule;
+import org.marketdesignresearch.mechlib.outcomerules.ccg.blockingallocation.XORBlockingCoalitionFinderFactory;
+import org.marketdesignresearch.mechlib.outcomerules.ccg.constraintgeneration.ConstraintGenerationAlgorithm;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.paymentrules.EqualWeightsFactory;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.paymentrules.InversePayoffWeightsFactory;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.paymentrules.Norm;
@@ -31,6 +36,29 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 public class PaymentRuleTests {
+    @Test
+    public void testSimpleExample() {
+        CPLEXUtils.SOLVER.initializeSolveParams();
+        SimpleGood west = new SimpleGood("west", 2, false);
+
+        BundleValue valueWest1 = new BundleValue(BigDecimal.valueOf(2), Bundle.of(west));
+        XORBidder westBidder1 = new XORBidder("west1", new XORValueFunction(ImmutableSet.of(valueWest1)));
+
+        BundleValue valueWest2 = new BundleValue(BigDecimal.valueOf(2), Bundle.of(west));
+        XORBidder westBidder2 = new XORBidder("west2", new XORValueFunction(ImmutableSet.of(valueWest2)));
+
+        BundleValue globalBundle = new BundleValue(BigDecimal.valueOf(3), new Bundle(Map.of(west, 2)), "global");
+        XORBidder globalBidder = new XORBidder("global", new XORValueFunction(ImmutableSet.of(globalBundle)));
+
+        SimpleXORDomain domain = new SimpleXORDomain(ImmutableList.of(westBidder1, westBidder2, globalBidder), ImmutableList.of(west));
+        MechanismFactory equalNorm = new VariableAlgorithmCCGFactory(new XORBlockingCoalitionFinderFactory(), ConstraintGenerationAlgorithm.STANDARD_CCG);
+        OutcomeRule outcomeRule = equalNorm.getOutcomeRule(BundleExactValueBids.fromXORBidders(domain.getBidders()));
+        Payment payment = outcomeRule.getPayment();
+        assertThat(payment.paymentOf(westBidder2).getAmount()).isEqualByComparingTo(BigDecimal.valueOf(1.5));
+        assertThat(payment.paymentOf(westBidder1).getAmount()).isEqualByComparingTo(BigDecimal.valueOf(1.5));
+
+    }
+
     @Test
     public void testEqualRule() {
         CPLEXUtils.SOLVER.initializeSolveParams();
@@ -53,6 +81,30 @@ public class PaymentRuleTests {
         Payment payment = outcomeRule.getPayment();
         assertThat(payment.paymentOf(eastBidder).getAmount()).isEqualByComparingTo(BigDecimal.valueOf(1.75));
         assertThat(payment.paymentOf(westBidder).getAmount()).isEqualByComparingTo(BigDecimal.valueOf(.25));
+
+    }
+
+    @Test
+    public void testEqualRuleGeneric() {
+        CPLEXUtils.SOLVER.initializeSolveParams();
+        SimpleGood west = new SimpleGood("west", 2, false);
+
+        BundleValue valueWest1 = new BundleValue(BigDecimal.valueOf(1), Bundle.of(west));
+        XORBidder westBidder1 = new XORBidder("west1", new XORValueFunction(ImmutableSet.of(valueWest1)));
+
+        BundleValue valueWest2 = new BundleValue(BigDecimal.valueOf(2.5), Bundle.of(west));
+        XORBidder westBidder2 = new XORBidder("west2", new XORValueFunction(ImmutableSet.of(valueWest2)));
+
+        BundleValue globalBundle = new BundleValue(BigDecimal.valueOf(2), new Bundle(Map.of(west, 2)), "global");
+        XORBidder globalBidder = new XORBidder("global", new XORValueFunction(ImmutableSet.of(globalBundle)));
+
+        SimpleXORDomain domain = new SimpleXORDomain(ImmutableList.of(westBidder1, westBidder2, globalBidder), ImmutableList.of(west));
+        MechanismFactory equalNorm = new VariableNormCCGFactory(new BidsReferencePointFactory(), new NormFactory(Norm.MANHATTAN, new EqualWeightsFactory(), Payment.ZERO),
+                NormFactory.withEqualWeights(Norm.EUCLIDEAN));
+        OutcomeRule outcomeRule = equalNorm.getOutcomeRule(BundleExactValueBids.fromXORBidders(domain.getBidders()));
+        Payment payment = outcomeRule.getPayment();
+        assertThat(payment.paymentOf(westBidder2).getAmount()).as("FIXME: This should produce the same result as above. Seems like something needs to be modified in the norms / reference points /...").isEqualByComparingTo(BigDecimal.valueOf(1.75));
+        assertThat(payment.paymentOf(westBidder1).getAmount()).isEqualByComparingTo(BigDecimal.valueOf(.25));
 
     }
 

--- a/src/test/java/org/marketdesignresearch/mechlib/winnerdetermination/WinnerDeterminationTest.java
+++ b/src/test/java/org/marketdesignresearch/mechlib/winnerdetermination/WinnerDeterminationTest.java
@@ -16,6 +16,7 @@ import org.marketdesignresearch.mechlib.core.bid.bundle.BundleExactValuePair;
 import org.marketdesignresearch.mechlib.core.bidder.Bidder;
 import org.marketdesignresearch.mechlib.core.bidder.XORBidder;
 import org.marketdesignresearch.mechlib.outcomerules.AllocationRule;
+import org.marketdesignresearch.mechlib.outcomerules.OutcomeRule;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.CCGFactory;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.CCGOutcomeRule;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.paymentrules.Norm;
@@ -61,7 +62,7 @@ public class WinnerDeterminationTest {
         VCGReferencePointFactory rpFacory = new VCGReferencePointFactory();
         CCGFactory quadratic = new VariableNormCCGFactory(rpFacory, Norm.MANHATTAN, Norm.EUCLIDEAN);
 
-        CCGOutcomeRule ccgAuction = quadratic.getOutcomeRule(bids);
+        OutcomeRule ccgAuction = quadratic.getOutcomeRule(bids);
         Outcome outcome = ccgAuction.getOutcome();
         assertThat(outcome.getAllocation().getTotalAllocationValue()).isEqualByComparingTo("46");
         assertThat(outcome.getPayment().getTotalPayments()).isEqualByComparingTo("6");


### PR DESCRIPTION
CCG produces some errors when using MRVM as the bidders values are larger than MIP.MAX_VALUE

Instead of changing all MIPs I have chosen to scale all bids down before CCG outcome is computed and then scale the CCG outcome again up to match real values.

As it was to hard to implement this for the main branch I did it directly for the interaction branch.