### PR TITLE
CPLEX global scale

### DIFF
--- a/src/main/java/org/marketdesignresearch/mechlib/utils/CPLEXUtils.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/utils/CPLEXUtils.java
@@ -73,7 +73,7 @@ public enum CPLEXUtils {
      *      <li>TIME_LIMIT: 1 hour</li>
      *  </ul>
      */
-    public void initializeSolveParams() {
+    public void exampleSolveParams() {
         clearSolveParams();
         setSolveParam(SolveParam.DISPLAY_OUTPUT, log.isDebugEnabled());
         setSolveParam(SolveParam.THREADS, 1);
@@ -84,8 +84,8 @@ public enum CPLEXUtils {
      * A helper function to initialize the solver with default parameters that were previously used in experiments
      * of very specific CCG-price calculation MIPs
      */
-    public void initializeNormSolveParams() {
-        initializeSolveParams();
+    public void exampleNormSolveParams() {
+        exampleSolveParams();
         setSolveParam(SolveParam.CALC_DUALS, Boolean.TRUE);
         setSolveParam(SolveParam.LP_OPTIMIZATION_ALG, 2);
         setSolveParam(SolveParam.PARALLEL_MODE, 1);

--- a/src/main/java/org/marketdesignresearch/mechlib/utils/CPLEXUtils.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/utils/CPLEXUtils.java
@@ -18,24 +18,55 @@ public enum CPLEXUtils {
 
     private final Map<SolveParam, Object> solveParamMap = Maps.newHashMap();
 
+    /**
+     * Solves the program.
+     * It applies the solve parameters that are specified in {@link #solveParamMap} only if they are not already
+     * specified in the program itself.
+     * Careful: JOpt has a default parameter logic as well, so often the program already includes JOpt-specific default
+     * parameters, which will not be overwritten here. To be sure, you can call {@link IMIP#clearSolveParams()} before
+     * setting your own parameters
+     * @param program The program to be solved
+     * @return The result object
+     */
     public IMIPResult solve(IMIP program) {
-        return solve(program, Map.of());
-    }
-
-    public IMIPResult solve(IMIP program, Map<SolveParam, Object> additionalParams) {
-        solveParamMap.forEach(program::setSolveParam);
-        additionalParams.forEach(program::setSolveParam);
+        solveParamMap.forEach((param , value) -> {
+            if (!program.isSolveParamSpecified(param)) {
+                program.setSolveParam(param, value);
+            }
+        });
         return solver.solve(program);
     }
 
+    /**
+     * You can add additional (or override existing) default parameters that are then applied to any future program
+     * that does not define these solve parameters by itself already.
+     * @param param The SolveParam to be specified
+     * @param value The value that should be set for the SolveParam
+     */
     public void setSolveParam(SolveParam param, Object value) {
         solveParamMap.put(param, value);
     }
 
+
+    /**
+     *  A helper function to initialize the solver with some reasonable default parameters.
+     *  Has to be actively called by the user.
+     */
     public void initializeSolveParams() {
+        solveParamMap.clear();
+        solveParamMap.put(SolveParam.DISPLAY_OUTPUT, log.isDebugEnabled());
+        solveParamMap.put(SolveParam.THREADS, 1);
+        solveParamMap.put(SolveParam.TIME_LIMIT, (double) TimeUnit.SECONDS.convert(1, TimeUnit.HOURS));
+    }
+
+    /**
+     * A helper function to initialize the solver with default parameters that were previously used in experiments
+     * of very specific CCG-price calculation MIPs
+     */
+    public void initializeNormSolveParams() {
+        initializeSolveParams();
         solveParamMap.put(SolveParam.CALC_DUALS, Boolean.TRUE);
         solveParamMap.put(SolveParam.LP_OPTIMIZATION_ALG, 2);
-        solveParamMap.put(SolveParam.DISPLAY_OUTPUT, log.isDebugEnabled());
         solveParamMap.put(SolveParam.PARALLEL_MODE, 1);
         solveParamMap.put(SolveParam.ABSOLUTE_VAR_BOUND_GAP, 1e-9);
         solveParamMap.put(SolveParam.ABSOLUTE_OBJ_GAP, 0d);
@@ -44,7 +75,6 @@ public enum CPLEXUtils {
         solveParamMap.put(SolveParam.MARKOWITZ_TOLERANCE, .1);
         solveParamMap.put(SolveParam.CONSTRAINT_BACKOFF_LIMIT, 0);
         solveParamMap.put(SolveParam.PROBLEM_FILE, "");
-        solveParamMap.put(SolveParam.TIME_LIMIT, (double) TimeUnit.SECONDS.convert(1, TimeUnit.HOURS));
         solveParamMap.put(SolveParam.SOLUTION_POOL_REPLACEMENT, 2);
     }
 

--- a/src/main/java/org/marketdesignresearch/mechlib/utils/CPLEXUtils.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/utils/CPLEXUtils.java
@@ -19,7 +19,12 @@ public enum CPLEXUtils {
     private final Map<SolveParam, Object> solveParamMap = Maps.newHashMap();
 
     public IMIPResult solve(IMIP program) {
+        return solve(program, Map.of());
+    }
+
+    public IMIPResult solve(IMIP program, Map<SolveParam, Object> additionalParams) {
         solveParamMap.forEach(program::setSolveParam);
+        additionalParams.forEach(program::setSolveParam);
         return solver.solve(program);
     }
 

--- a/src/main/java/org/marketdesignresearch/mechlib/utils/CPLEXUtils.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/utils/CPLEXUtils.java
@@ -33,6 +33,7 @@ public enum CPLEXUtils {
      * Careful: JOpt has a default parameter logic as well, so often the program already includes JOpt-specific default
      * parameters, which will not be overwritten here. To be sure, you can call {@link IMIP#clearSolveParams()} before
      * setting your own parameters
+     *
      * @param program The program to be solved
      * @return The result object
      */
@@ -55,10 +56,12 @@ public enum CPLEXUtils {
         solveParamMap.put(param, value);
     }
 
+    /**
+     * Clears the previously added solve parameters
+     */
     public void clearSolveParams() {
         solveParamMap.clear();
     }
-
 
     /**
      *  A helper function to initialize the solver with some reasonable default parameters.

--- a/src/main/java/org/marketdesignresearch/mechlib/utils/CPLEXUtils.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/utils/CPLEXUtils.java
@@ -10,6 +10,14 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A wrapper around the solving logic. By default, all solves in MechLib are solved through this singleton,
+ * which allows setting some parameters that are applied consistently among all MIPs that are solved inside the MechLib.
+ * E.g., you can specify a thread count here, and this will be applied to all MIPs that are to be solved.
+ * Parameters that are set on {@link IMIP}-level are NOT overwritten.
+ *
+ * This wrapper also exposes some methods to set default parameters in a way they have been set in experiments before.
+ */
 @Slf4j
 public enum CPLEXUtils {
     SOLVER;
@@ -38,7 +46,7 @@ public enum CPLEXUtils {
     }
 
     /**
-     * You can add additional (or override existing) default parameters that are then applied to any future program
+     * You can add additional (or override previously added) default parameters that are then applied to any future program
      * that does not define these solve parameters by itself already.
      * @param param The SolveParam to be specified
      * @param value The value that should be set for the SolveParam
@@ -47,16 +55,26 @@ public enum CPLEXUtils {
         solveParamMap.put(param, value);
     }
 
+    public void clearSolveParams() {
+        solveParamMap.clear();
+    }
+
 
     /**
      *  A helper function to initialize the solver with some reasonable default parameters.
      *  Has to be actively called by the user.
+     *  This sets the following:
+     *  <ul>
+     *      <li>DISPLAY_OUTPUT: according to the log level - only if the debug log level is enabled, it's set to true</li>
+     *      <li>THREADS: 1</li>
+     *      <li>TIME_LIMIT: 1 hour</li>
+     *  </ul>
      */
     public void initializeSolveParams() {
-        solveParamMap.clear();
-        solveParamMap.put(SolveParam.DISPLAY_OUTPUT, log.isDebugEnabled());
-        solveParamMap.put(SolveParam.THREADS, 1);
-        solveParamMap.put(SolveParam.TIME_LIMIT, (double) TimeUnit.SECONDS.convert(1, TimeUnit.HOURS));
+        clearSolveParams();
+        setSolveParam(SolveParam.DISPLAY_OUTPUT, log.isDebugEnabled());
+        setSolveParam(SolveParam.THREADS, 1);
+        setSolveParam(SolveParam.TIME_LIMIT, (double) TimeUnit.SECONDS.convert(1, TimeUnit.HOURS));
     }
 
     /**
@@ -65,17 +83,17 @@ public enum CPLEXUtils {
      */
     public void initializeNormSolveParams() {
         initializeSolveParams();
-        solveParamMap.put(SolveParam.CALC_DUALS, Boolean.TRUE);
-        solveParamMap.put(SolveParam.LP_OPTIMIZATION_ALG, 2);
-        solveParamMap.put(SolveParam.PARALLEL_MODE, 1);
-        solveParamMap.put(SolveParam.ABSOLUTE_VAR_BOUND_GAP, 1e-9);
-        solveParamMap.put(SolveParam.ABSOLUTE_OBJ_GAP, 0d);
-        solveParamMap.put(SolveParam.RELATIVE_OBJ_GAP, 0d);
-        solveParamMap.put(SolveParam.OBJ_TOLERANCE, 1e-9);
-        solveParamMap.put(SolveParam.MARKOWITZ_TOLERANCE, .1);
-        solveParamMap.put(SolveParam.CONSTRAINT_BACKOFF_LIMIT, 0);
-        solveParamMap.put(SolveParam.PROBLEM_FILE, "");
-        solveParamMap.put(SolveParam.SOLUTION_POOL_REPLACEMENT, 2);
+        setSolveParam(SolveParam.CALC_DUALS, Boolean.TRUE);
+        setSolveParam(SolveParam.LP_OPTIMIZATION_ALG, 2);
+        setSolveParam(SolveParam.PARALLEL_MODE, 1);
+        setSolveParam(SolveParam.ABSOLUTE_VAR_BOUND_GAP, 1e-9);
+        setSolveParam(SolveParam.ABSOLUTE_OBJ_GAP, 0d);
+        setSolveParam(SolveParam.RELATIVE_OBJ_GAP, 0d);
+        setSolveParam(SolveParam.OBJ_TOLERANCE, 1e-9);
+        setSolveParam(SolveParam.MARKOWITZ_TOLERANCE, .1);
+        setSolveParam(SolveParam.CONSTRAINT_BACKOFF_LIMIT, 0);
+        setSolveParam(SolveParam.PROBLEM_FILE, "");
+        setSolveParam(SolveParam.SOLUTION_POOL_REPLACEMENT, 2);
     }
 
 }

--- a/src/main/java/org/marketdesignresearch/mechlib/utils/CPLEXUtils.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/utils/CPLEXUtils.java
@@ -1,15 +1,14 @@
 package org.marketdesignresearch.mechlib.utils;
 
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
 import com.google.common.collect.Maps;
-
 import edu.harvard.econcs.jopt.solver.IMIP;
 import edu.harvard.econcs.jopt.solver.IMIPResult;
 import edu.harvard.econcs.jopt.solver.SolveParam;
 import edu.harvard.econcs.jopt.solver.server.cplex.CPlexMIPSolver;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 public enum CPLEXUtils {
@@ -22,6 +21,10 @@ public enum CPLEXUtils {
     public IMIPResult solve(IMIP program) {
         solveParamMap.forEach(program::setSolveParam);
         return solver.solve(program);
+    }
+
+    public void setSolveParam(SolveParam param, Object value) {
+        solveParamMap.put(param, value);
     }
 
     public void initializeSolveParams() {

--- a/src/main/java/org/marketdesignresearch/mechlib/winnerdetermination/WinnerDetermination.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/winnerdetermination/WinnerDetermination.java
@@ -1,30 +1,24 @@
 package org.marketdesignresearch.mechlib.winnerdetermination;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
-import org.marketdesignresearch.mechlib.core.Allocation;
-import org.marketdesignresearch.mechlib.instrumentation.MipInstrumentation;
-import org.marketdesignresearch.mechlib.outcomerules.AllocationRule;
-
 import com.google.common.collect.Lists;
-
-import edu.harvard.econcs.jopt.solver.IMIP;
-import edu.harvard.econcs.jopt.solver.IMIPResult;
-import edu.harvard.econcs.jopt.solver.ISolution;
-import edu.harvard.econcs.jopt.solver.MIPException;
-import edu.harvard.econcs.jopt.solver.SolveParam;
-import edu.harvard.econcs.jopt.solver.client.SolverClient;
+import edu.harvard.econcs.jopt.solver.*;
 import edu.harvard.econcs.jopt.solver.mip.MIP;
 import edu.harvard.econcs.jopt.solver.mip.PoolSolution;
 import edu.harvard.econcs.jopt.solver.mip.Variable;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.marketdesignresearch.mechlib.core.Allocation;
+import org.marketdesignresearch.mechlib.instrumentation.MipInstrumentation;
+import org.marketdesignresearch.mechlib.outcomerules.AllocationRule;
+import org.marketdesignresearch.mechlib.utils.CPLEXUtils;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 @Slf4j
 public abstract class WinnerDetermination implements AllocationRule {
@@ -83,7 +77,7 @@ public abstract class WinnerDetermination implements AllocationRule {
         getMIP().setSolveParam(SolveParam.ACCEPT_SUBOPTIMAL, acceptSuboptimal);
         try {
         	mipInstrumentation.preMIP(purpose, getMIP());
-            IMIPResult mipResult = new SolverClient().solve(getMIP());
+            IMIPResult mipResult = CPLEXUtils.SOLVER.solve(getMIP());
             intermediateSolutions = solveIntermediateSolutions(mipResult);
             Allocation bestAllocation = adaptMIPResult(mipResult);
             mipInstrumentation.postMIP(purpose, getMIP(), mipResult, bestAllocation, intermediateSolutions);

--- a/src/test/java/org/marketdesignresearch/mechlib/outcomerules/OutcomeRuleScalerTest.java
+++ b/src/test/java/org/marketdesignresearch/mechlib/outcomerules/OutcomeRuleScalerTest.java
@@ -27,7 +27,7 @@ public class OutcomeRuleScalerTest {
     @Test
     public void testScalerForCCG() {
 
-        CPLEXUtils.SOLVER.initializeSolveParams();
+        CPLEXUtils.SOLVER.exampleSolveParams();
         SimpleGood west = new SimpleGood("west", 2, false);
 
         BundleValue valueWest1 = new BundleValue(BigDecimal.valueOf(2e15), Bundle.of(west));
@@ -49,7 +49,7 @@ public class OutcomeRuleScalerTest {
     
     @Test
     public void testScalerForCCGinORDomain() {
-        CPLEXUtils.SOLVER.initializeSolveParams();
+        CPLEXUtils.SOLVER.exampleSolveParams();
         SimpleGood west = new SimpleGood("west", 2, false);
 
         BundleValue valueWest1 = new BundleValue(BigDecimal.valueOf(2e15), Bundle.of(west));

--- a/src/test/java/org/marketdesignresearch/mechlib/outcomerules/ccg/CCGOutcomeRuleTest.java
+++ b/src/test/java/org/marketdesignresearch/mechlib/outcomerules/ccg/CCGOutcomeRuleTest.java
@@ -45,7 +45,7 @@ public class CCGOutcomeRuleTest {
 
     public CCGOutcomeRuleTest(MechanismFactory factory) {
         this.factory = factory;
-        CPLEXUtils.SOLVER.initializeNormSolveParams();
+        CPLEXUtils.SOLVER.exampleNormSolveParams();
     }
 
     @Parameterized.Parameters

--- a/src/test/java/org/marketdesignresearch/mechlib/outcomerules/ccg/CCGOutcomeRuleTest.java
+++ b/src/test/java/org/marketdesignresearch/mechlib/outcomerules/ccg/CCGOutcomeRuleTest.java
@@ -45,7 +45,7 @@ public class CCGOutcomeRuleTest {
 
     public CCGOutcomeRuleTest(MechanismFactory factory) {
         this.factory = factory;
-        CPLEXUtils.SOLVER.initializeSolveParams();
+        CPLEXUtils.SOLVER.initializeNormSolveParams();
     }
 
     @Parameterized.Parameters

--- a/src/test/java/org/marketdesignresearch/mechlib/outcomerules/ccg/PaymentRuleTests.java
+++ b/src/test/java/org/marketdesignresearch/mechlib/outcomerules/ccg/PaymentRuleTests.java
@@ -39,7 +39,7 @@ import com.google.common.collect.ImmutableSet;
 public class PaymentRuleTests {
     @Test
     public void testSimpleExample() {
-        CPLEXUtils.SOLVER.initializeSolveParams();
+        CPLEXUtils.SOLVER.initializeNormSolveParams();
         SimpleGood west = new SimpleGood("west", 2, false);
 
         BundleValue valueWest1 = new BundleValue(BigDecimal.valueOf(2), Bundle.of(west));
@@ -62,7 +62,7 @@ public class PaymentRuleTests {
 
     @Test
     public void testEqualRule() {
-        CPLEXUtils.SOLVER.initializeSolveParams();
+        CPLEXUtils.SOLVER.initializeNormSolveParams();
         SimpleGood west = new SimpleGood("west");
         SimpleGood east = new SimpleGood("east");
 
@@ -87,7 +87,7 @@ public class PaymentRuleTests {
 
     @Test
     public void testEqualRuleGeneric() {
-        CPLEXUtils.SOLVER.initializeSolveParams();
+        CPLEXUtils.SOLVER.initializeNormSolveParams();
         SimpleGood west = new SimpleGood("west", 2, false);
 
         BundleValue valueWest1 = new BundleValue(BigDecimal.valueOf(1), Bundle.of(west));
@@ -112,7 +112,7 @@ public class PaymentRuleTests {
     
     @Test
     public void testEqualRulePerBidConstraintGenerator() {
-        CPLEXUtils.SOLVER.initializeSolveParams();
+        CPLEXUtils.SOLVER.initializeNormSolveParams();
         SimpleGood west = new SimpleGood("west");
         SimpleGood east = new SimpleGood("east");
 
@@ -137,7 +137,7 @@ public class PaymentRuleTests {
 
     @Test
     public void testEqualRuleGenericPerBidConstraintGenerator() {
-        CPLEXUtils.SOLVER.initializeSolveParams();
+        CPLEXUtils.SOLVER.initializeNormSolveParams();
         SimpleGood west = new SimpleGood("west", 2, false);
 
         BundleValue valueWest1 = new BundleValue(BigDecimal.valueOf(1), Bundle.of(west));
@@ -168,7 +168,7 @@ public class PaymentRuleTests {
 
     @Test
     public void paperExample() throws IOException {
-        CPLEXUtils.SOLVER.initializeSolveParams();
+        CPLEXUtils.SOLVER.initializeNormSolveParams();
         BundleValueBids<?> bids = BundleExactValueBids.fromXORBidders(SimpleXORDomain.fromCatsFile(Paths.get("src/test/resources/supersimple.txt")).getBidders());
         MechanismFactory quadratic = new VariableNormCCGFactory(new VCGReferencePointFactory(), NormFactory.withEqualWeights(Norm.MANHATTAN),
                 NormFactory.withEqualWeights(Norm.EUCLIDEAN));

--- a/src/test/java/org/marketdesignresearch/mechlib/outcomerules/ccg/PaymentRuleTests.java
+++ b/src/test/java/org/marketdesignresearch/mechlib/outcomerules/ccg/PaymentRuleTests.java
@@ -39,7 +39,7 @@ import com.google.common.collect.ImmutableSet;
 public class PaymentRuleTests {
     @Test
     public void testSimpleExample() {
-        CPLEXUtils.SOLVER.initializeNormSolveParams();
+        CPLEXUtils.SOLVER.exampleNormSolveParams();
         SimpleGood west = new SimpleGood("west", 2, false);
 
         BundleValue valueWest1 = new BundleValue(BigDecimal.valueOf(2), Bundle.of(west));
@@ -62,7 +62,7 @@ public class PaymentRuleTests {
 
     @Test
     public void testEqualRule() {
-        CPLEXUtils.SOLVER.initializeNormSolveParams();
+        CPLEXUtils.SOLVER.exampleNormSolveParams();
         SimpleGood west = new SimpleGood("west");
         SimpleGood east = new SimpleGood("east");
 
@@ -87,7 +87,7 @@ public class PaymentRuleTests {
 
     @Test
     public void testEqualRuleGeneric() {
-        CPLEXUtils.SOLVER.initializeNormSolveParams();
+        CPLEXUtils.SOLVER.exampleNormSolveParams();
         SimpleGood west = new SimpleGood("west", 2, false);
 
         BundleValue valueWest1 = new BundleValue(BigDecimal.valueOf(1), Bundle.of(west));
@@ -112,7 +112,7 @@ public class PaymentRuleTests {
     
     @Test
     public void testEqualRulePerBidConstraintGenerator() {
-        CPLEXUtils.SOLVER.initializeNormSolveParams();
+        CPLEXUtils.SOLVER.exampleNormSolveParams();
         SimpleGood west = new SimpleGood("west");
         SimpleGood east = new SimpleGood("east");
 
@@ -137,7 +137,7 @@ public class PaymentRuleTests {
 
     @Test
     public void testEqualRuleGenericPerBidConstraintGenerator() {
-        CPLEXUtils.SOLVER.initializeNormSolveParams();
+        CPLEXUtils.SOLVER.exampleNormSolveParams();
         SimpleGood west = new SimpleGood("west", 2, false);
 
         BundleValue valueWest1 = new BundleValue(BigDecimal.valueOf(1), Bundle.of(west));
@@ -168,7 +168,7 @@ public class PaymentRuleTests {
 
     @Test
     public void paperExample() throws IOException {
-        CPLEXUtils.SOLVER.initializeNormSolveParams();
+        CPLEXUtils.SOLVER.exampleNormSolveParams();
         BundleValueBids<?> bids = BundleExactValueBids.fromXORBidders(SimpleXORDomain.fromCatsFile(Paths.get("src/test/resources/supersimple.txt")).getBidders());
         MechanismFactory quadratic = new VariableNormCCGFactory(new VCGReferencePointFactory(), NormFactory.withEqualWeights(Norm.MANHATTAN),
                 NormFactory.withEqualWeights(Norm.EUCLIDEAN));

--- a/src/test/java/org/marketdesignresearch/mechlib/winnerdetermination/WinnerDeterminationTest.java
+++ b/src/test/java/org/marketdesignresearch/mechlib/winnerdetermination/WinnerDeterminationTest.java
@@ -19,7 +19,6 @@ import org.marketdesignresearch.mechlib.core.bidder.XORBidder;
 import org.marketdesignresearch.mechlib.outcomerules.AllocationRule;
 import org.marketdesignresearch.mechlib.outcomerules.OutcomeRule;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.CCGFactory;
-import org.marketdesignresearch.mechlib.outcomerules.ccg.CCGOutcomeRule;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.paymentrules.Norm;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.paymentrules.VariableNormCCGFactory;
 import org.marketdesignresearch.mechlib.outcomerules.ccg.referencepoint.VCGReferencePointFactory;
@@ -46,7 +45,7 @@ public class WinnerDeterminationTest {
 
     @Test
     public void testBidReduction() {
-        CPLEXUtils.SOLVER.initializeSolveParams();
+        CPLEXUtils.SOLVER.exampleSolveParams();
         CPLEXUtils.SOLVER.setSolveParam(SolveParam.RELATIVE_OBJ_GAP, 1e-6d);
         BundleExactValuePair bid1 = new BundleExactValuePair(BigDecimal.valueOf(6), Sets.newHashSet(A), "1");
         BundleExactValuePair bid2 = new BundleExactValuePair(BigDecimal.valueOf(20), Sets.newHashSet(B), "2");

--- a/src/test/java/org/marketdesignresearch/mechlib/winnerdetermination/WinnerDeterminationTest.java
+++ b/src/test/java/org/marketdesignresearch/mechlib/winnerdetermination/WinnerDeterminationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 
+import edu.harvard.econcs.jopt.solver.SolveParam;
 import org.junit.Before;
 import org.junit.Test;
 import org.marketdesignresearch.mechlib.core.Allocation;
@@ -46,6 +47,7 @@ public class WinnerDeterminationTest {
     @Test
     public void testBidReduction() {
         CPLEXUtils.SOLVER.initializeSolveParams();
+        CPLEXUtils.SOLVER.setSolveParam(SolveParam.RELATIVE_OBJ_GAP, 1e-6d);
         BundleExactValuePair bid1 = new BundleExactValuePair(BigDecimal.valueOf(6), Sets.newHashSet(A), "1");
         BundleExactValuePair bid2 = new BundleExactValuePair(BigDecimal.valueOf(20), Sets.newHashSet(B), "2");
         BundleExactValuePair bid3 = new BundleExactValuePair(BigDecimal.valueOf(20), Sets.newHashSet(C), "3");


### PR DESCRIPTION
@beyeler 
This is a proposition for #16 . That way, all internal `.solve()` calls go through a singleton, which can take in any parameters that should be used as default beforehand. It's also possible to solve problems in parallel with non-default parameters by passing additional SolveParams. It may be required to propagate passing these additional parameters further up (e.g., to WinnerDetermination, ModelMIPs, etc.), but that way the basic logic is there (and setting the default parameters for all runs probably resolves #16 already).
