### PR TITLE
Bundle sampling

### DIFF
--- a/src/main/java/org/marketdesignresearch/mechlib/core/Domain.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/Domain.java
@@ -4,14 +4,12 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.marketdesignresearch.mechlib.core.bidder.Bidder;
+import org.marketdesignresearch.mechlib.core.bundlesampling.BundleSampling;
 import org.marketdesignresearch.mechlib.core.price.LinearPrices;
 import org.marketdesignresearch.mechlib.core.price.Price;
 import org.marketdesignresearch.mechlib.core.price.Prices;
@@ -116,22 +114,16 @@ public interface Domain extends MipInstrumentationable {
         });
         return new LinearPrices(priceMap);
     }
-    
+
+
     /**
-     * This method generates a uniform random bundle in this domain. By default, the 
-     * the method generates a uniform bundle using the goods describing this domain.
-     * 
-     * @param random the random object that will be used to sample the random bundle
+     * This method provides a sampled bundle based on a sampling method.
+     *
+     * @param sampling the {@link BundleSampling} that should be applied
      * @return a uniform random bundle of this domain
      */
-    default Bundle getRandomBundle(Random random) {
-		Set<BundleEntry> bundleEntries = new HashSet<>();
-		for (Good g : this.getGoods()) {
-			int amount = (int) Math.floor(random.nextDouble() * (g.getQuantity() + 1));
-			if (amount > 0)
-				bundleEntries.add(new BundleEntry(g, amount));
-		}
-		return new Bundle(bundleEntries);
+    default Bundle getSampledBundle(BundleSampling sampling) {
+        return sampling.getSingleBundle(getGoods());
 	}
 
     default String getName() {

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bundlesampling/BundleSampling.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bundlesampling/BundleSampling.java
@@ -1,0 +1,19 @@
+package org.marketdesignresearch.mechlib.core.bundlesampling;
+
+import org.marketdesignresearch.mechlib.core.Bundle;
+import org.marketdesignresearch.mechlib.core.Good;
+
+import java.util.List;
+
+/**
+ * This interface is implemented by bundle sampling methods that are based on a list of goods.
+ */
+public interface BundleSampling {
+    /**
+     * Get a single good based on a list of goods.
+     *
+     * @param goods a list of {@link Good}s
+     * @return a sampled {@link Bundle}
+     */
+    Bundle getSingleBundle(List<? extends Good> goods);
+}

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bundlesampling/LimitedSizeRandomBundleSampling.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bundlesampling/LimitedSizeRandomBundleSampling.java
@@ -1,0 +1,43 @@
+package org.marketdesignresearch.mechlib.core.bundlesampling;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import lombok.RequiredArgsConstructor;
+import org.marketdesignresearch.mechlib.core.Bundle;
+import org.marketdesignresearch.mechlib.core.BundleEntry;
+import org.marketdesignresearch.mechlib.core.Good;
+
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This sampler returns a random bundle among all possible bundles with a size below a certain limit.
+ * No information is preserved, there is no guarantee that you can't get the same bundle twice.
+ */
+@RequiredArgsConstructor
+public class LimitedSizeRandomBundleSampling implements BundleSampling {
+
+    public LimitedSizeRandomBundleSampling(int sizeLimit) {
+        this(sizeLimit, new Random());
+    }
+
+    private final int sizeLimit;
+    private final Random random;
+
+    @Override
+    public Bundle getSingleBundle(List<? extends Good> goods) {
+        if (goods.size() > 30) {
+            throw new IllegalArgumentException("Cannot build a powerset of more than 30 goods. In future, this" +
+                    " implementation could be more efficient by only creating a powerset of with bundles of <= sizeLimit.");
+        }
+        if (goods.stream().anyMatch(good -> good.getQuantity() > 1)) {
+            throw new IllegalArgumentException("This bundle sampling currently only supports goods with quantity of 1");
+        }
+        Set<? extends Set<? extends Good>> powerSet = Sets.powerSet(Sets.newHashSet(goods));
+        Set<? extends Set<? extends Good>> filteredSet = powerSet.stream().filter(set -> set.size() <= sizeLimit).collect(Collectors.toSet());
+        Set<? extends Good> singleSet = Lists.newArrayList(filteredSet).get((int) Math.round(random.nextDouble() * filteredSet.size()));
+        return new Bundle(singleSet.stream().map(good -> new BundleEntry(good, 1)).collect(Collectors.toSet()));
+    }
+}

--- a/src/main/java/org/marketdesignresearch/mechlib/core/bundlesampling/UniformRandomBundleSampling.java
+++ b/src/main/java/org/marketdesignresearch/mechlib/core/bundlesampling/UniformRandomBundleSampling.java
@@ -1,0 +1,38 @@
+package org.marketdesignresearch.mechlib.core.bundlesampling;
+
+import lombok.RequiredArgsConstructor;
+import org.marketdesignresearch.mechlib.core.Bundle;
+import org.marketdesignresearch.mechlib.core.BundleEntry;
+import org.marketdesignresearch.mechlib.core.Good;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * This class samples a random bundle from a list of goods.
+ * Each good as a 50% chance to be included in the bundle. Thus, if a good has a quantity of 2, the chance that
+ * at least one of the individual goods are included is already at 75%.
+ * No information is preserved, there is no guarantee that you can't get the same bundle twice.
+ */
+@RequiredArgsConstructor
+public class UniformRandomBundleSampling implements BundleSampling {
+
+    public UniformRandomBundleSampling() {
+        this(new Random());
+    }
+
+    private final Random random;
+
+    @Override
+    public Bundle getSingleBundle(List<? extends Good> goods) {
+        Set<BundleEntry> bundleEntries = new HashSet<>();
+        for (Good g : goods) {
+            int amount = (int) Math.floor(random.nextDouble() * (g.getQuantity() + 1));
+            if (amount > 0)
+                bundleEntries.add(new BundleEntry(g, amount));
+        }
+        return new Bundle(bundleEntries);
+    }
+}

--- a/src/test/java/org/marketdesignresearch/mechlib/core/bundlesampling/BundleSamplingTest.java
+++ b/src/test/java/org/marketdesignresearch/mechlib/core/bundlesampling/BundleSamplingTest.java
@@ -1,0 +1,46 @@
+package org.marketdesignresearch.mechlib.core.bundlesampling;
+
+import org.junit.Test;
+import org.marketdesignresearch.mechlib.core.Bundle;
+import org.marketdesignresearch.mechlib.core.Domain;
+import org.marketdesignresearch.mechlib.input.cats.CATSAdapter;
+import org.marketdesignresearch.mechlib.input.cats.CATSAuction;
+import org.marketdesignresearch.mechlib.input.cats.CATSParser;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Random;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class BundleSamplingTest {
+    @Test
+    public void testUniformRandomBundleSampling() throws IOException {
+        Path catsFileStream = Paths.get("src/test/resources/day2007example.txt");
+        CATSParser parser = new CATSParser();
+        CATSAuction catsAuction = parser.readCatsAuctionBean(catsFileStream);
+        CATSAdapter adapter = new CATSAdapter();
+        Domain domain = adapter.adaptToDomain(catsAuction);
+        BundleSampling sampling = new UniformRandomBundleSampling(new Random(2));
+        Bundle sampled = domain.getSampledBundle(sampling);
+        assertThat(sampled.getSingleQuantityGoods(), is(List.of(domain.getGood("0"), domain.getGood("1"), domain.getGood("3"))));
+        System.out.println(sampled);
+    }
+
+    @Test
+    public void testLimitedSizeRandomBundleSampling() throws IOException {
+        Path catsFileStream = Paths.get("src/test/resources/day2007example.txt");
+        CATSParser parser = new CATSParser();
+        CATSAuction catsAuction = parser.readCatsAuctionBean(catsFileStream);
+        CATSAdapter adapter = new CATSAdapter();
+        Domain domain = adapter.adaptToDomain(catsAuction);
+        BundleSampling sampling = new LimitedSizeRandomBundleSampling(2, new Random(2));
+        Bundle sampled = domain.getSampledBundle(sampling);
+        assertThat(sampled.getSingleQuantityGoods(), is(List.of(domain.getGood("0"), domain.getGood("1"))));
+        System.out.println(sampled);
+    }
+
+}


### PR DESCRIPTION
Closes #20 .

@beyeler , I added a new component to sample bundles out of a list of goods. I also added drafts for the first two samplings - your method, and a limited size sampling. It is not implemented in an efficient way, but I think it's good enough to leave it this way for now and improve it in future. A user is also free to implement their own samplers.

As far as I remembered, I was making the link to the iterators in SATS that we have, that are going a step further than such samplers here. These iterators are e.g. taking into account that certain bundles were already asked for, and there are some that can handle XORQ and large domains in an efficient and random way. That's where I think it gets tricky, and that's also why I think there's such a large effort in SATS to implement this in a nice way. We could think about adapting such iterators for the mechlib - however, I think a simple sampler interface is also value added for the mechlib, so I'm not suggesting to replace the changes I've pushed, but rather maybe adding the iterator logic in addition to the samplers.